### PR TITLE
celery: fix module imports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,12 +24,12 @@ RUN curl https://bootstrap.pypa.io/get-pip.py | python -
 RUN pip install celery==3.1.17
 RUN pip install https://github.com/diana-hep/packtivity/archive/master.zip
 RUN pip install https://github.com/diana-hep/yadage/archive/master.zip
-ADD . /workdir/worker
-WORKDIR /workdir
+ADD . /code
+WORKDIR /code
 ARG QUEUE_ENV=default
 ENV QUEUE_ENV ${QUEUE_ENV}
 ENV PYTHONPATH=/workdir
-ENV PACKTIVITY_ASYNCBACKEND worker.externalbackend:ExternalBackend:ExternalProxy
+ENV PACKTIVITY_ASYNCBACKEND reana_workflow_engine_yadage.externalbackend:ExternalBackend:ExternalProxy
 RUN yum install -y openssh-clients
 RUN pip install zmq
-CMD celery -A worker.celeryapp worker -l info -Q ${QUEUE_ENV}
+CMD celery -A reana_workflow_engine_yadage.celeryapp worker -l info -Q ${QUEUE_ENV}

--- a/reana_workflow_engine_yadage/celeryapp.py
+++ b/reana_workflow_engine_yadage/celeryapp.py
@@ -26,7 +26,7 @@ from celery import Celery
 app = Celery('tasks',
              broker='amqp://test:1234@'
                     'message-broker.default.svc.cluster.local//',
-             include=['worker.tasks'])
+             include=['reana_workflow_engine_yadage.tasks'])
 
 
 app.conf.update(CELERY_ACCEPT_CONTENT=['json'],

--- a/reana_workflow_engine_yadage/tasks.py
+++ b/reana_workflow_engine_yadage/tasks.py
@@ -25,11 +25,11 @@ from __future__ import absolute_import, print_function
 import logging
 import os
 
-import worker.celery_zeromq
+import reana_workflow_engine_yadage.celery_zeromq
 import zmq
 
-from worker.celeryapp import app
-from worker.zeromq_tracker import ZeroMQTracker
+from reana_workflow_engine_yadage.celeryapp import app
+from reana_workflow_engine_yadage.zeromq_tracker import ZeroMQTracker
 from yadage.clihelpers import setupbackend_fromstring
 from yadage.steering_api import steering_ctx
 
@@ -40,7 +40,7 @@ API_VERSION = 'api/v1.0'
 def run_yadage_workflow_standalone(jobguid, ctx):
     log.info('getting socket..')
 
-    zmqctx = worker.celery_zeromq.get_context()
+    zmqctx = reana_workflow_engine_yadage.celery_zeromq.get_context()
     socket = zmqctx.socket(zmq.PUB)
     socket.connect(os.environ['ZMQ_PROXY_CONNECT'])
 


### PR DESCRIPTION
* Previous module structure imports have been renamed to
  to current reana_workflow_engine_yadage and therefore Dockerfile
  has been amended. (closes #10)

Signed-off-by: Diego Rodriguez <diego.rodriguez@cern.ch>