### PR TITLE
docs: structure improvements and new chapters

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,33 @@
+Contributing
+============
+
+Issues
+------
+
+Bug reports, feature requests, and other contributions are welcome. If you find
+a demonstrable problem that is caused by the REANA code, please:
+
+1. Search for `already reported problems
+   <https://github.com/reanahub/reana-workflow-engine-yadage/issues>`_.
+2. Check if the issue has been fixed or is still reproducible on the
+   latest `master` branch.
+3. Create an issue, ideally with **a test case**.
+
+Pull requests
+-------------
+
+If you create a feature branch, you can run the tests to ensure that everything
+is operating correctly:
+
+.. code-block:: console
+
+    $ ./run-tests.sh
+
+Each pull request should preserve or increase code coverage.
+
+Kanban
+------
+
+We are using Kanban technique for keeping track of ongoing tasks. Please see our
+`Kanban board <https://waffle.io/reanahub/reana>`_ and look for issues that are
+labelled as "ready for work".

--- a/README.rst
+++ b/README.rst
@@ -2,4 +2,22 @@
  REANA Workflow Engine Yadage
 ==============================
 
+.. image:: https://img.shields.io/travis/reanahub/reana-workflow-engine-yadage.svg
+      :target: https://travis-ci.org/reanahub/reana-workflow-engine-yadage
+
+.. image:: https://img.shields.io/coveralls/reanahub/reana-workflow-engine-yadage.svg
+      :target: https://coveralls.io/r/reanahub/reana-workflow-engine-yadage
+
+.. image:: https://readthedocs.org/projects/docs/badge/?version=latest
+      :target: https://reana-workflow-engine-yadage.readthedocs.io/en/latest/?badge=latest
+
+.. image:: https://badge.waffle.io/reanahub/reana.svg?label=Status%3A%20ready%20for%20work&title=Issues%20ready%20for%20work
+      :target: https://waffle.io/reanahub/reana
+
+.. image:: https://badges.gitter.im/Join%20Chat.svg
+      :target: https://gitter.im/reanahub/reana?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge
+
+.. image:: https://img.shields.io/github/license/reanahub/reana-workflow-engine-yadage.svg
+      :target: https://github.com/reanahub/reana-workflow-engine-yadage/blob/master/COPYING
+
 The workflow engine yadage component of the REANA system.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,6 +33,9 @@ import sphinx.environment
 #
 # needs_sphinx = '1.0'
 
+# Do not warn on external images.
+suppress_warnings = ['image.nonlocal_uri']
+
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,0 +1,1 @@
+.. include:: ../CONTRIBUTING.rst

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -1,0 +1,4 @@
+Getting started
+===============
+
+FIXME

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,9 @@
    :numbered:
    :maxdepth: 2
 
-   usage
+   introduction
+   gettingstarted
+   contributing
    changes
    license
    authors

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -1,0 +1,18 @@
+Introduction
+============
+
+About
+-----
+
+REANA-Workflow-Engine-Yadage is a component of the `REANA
+<http://reanahub.io/>`_ system. It takes care of instantiating and managing
+`Yadage <https://github.com/diana-hep/yadage>`_ workflows. Please see the
+`general REANA documentation <http://reana.readthedocs.io/>`_ if you would like
+to know more about the use of this component within the wider REANA framework.
+
+Features
+--------
+
+- start workflows
+- control workflow steps
+- support for `Yadage <https://github.com/diana-hep/yadage>`_ workflows

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -18,13 +18,4 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
-include Dockerfile
-include COPYING
-include *.rst
-include *.sh
-include pytest.ini
-recursive-include docs *.py
-recursive-include docs *.png
-recursive-include docs *.rst
-recursive-include docs *.txt
-recursive-include tests *.py
+-e .[all]

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,4 +1,0 @@
-Usage
-=====
-
-FIXME


### PR DESCRIPTION
* Adds more documentation chapters (Introduction, Getting started,
  Contributing).

* Adds Travis/Coveralls/RFTD/Waffle/Travis/License badges.

* Adds `docs/requirements.txt` so that ReadTheDocs can install all the
  prerequisites for building the autodoc parts of the documentation.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>