### PR TITLE
job-submission: add job logs call

### DIFF
--- a/reana_workflow_engine_yadage/submit.py
+++ b/reana_workflow_engine_yadage/submit.py
@@ -64,3 +64,16 @@ def check_status(job_id):
 
     job_info = response.json()['job']
     return job_info
+
+
+def get_logs(job_id):
+    response = requests.get(
+        'http://{host}/{resource}/{id}/logs'.format(
+            host=JOBCONTROLLER_HOST,
+            resource='jobs',
+            id=job_id
+        ),
+        headers={'cache-control': 'no-cache'}
+    )
+
+    return response.text

--- a/reana_workflow_engine_yadage/submit.py
+++ b/reana_workflow_engine_yadage/submit.py
@@ -32,9 +32,9 @@ log = logging.getLogger('yadage.cap.submit')
 def submit(experiment, image, cmd):
     job_spec = {
         'experiment': experiment,
-        'docker-img': image,
+        'docker_img': image,
         'cmd': cmd,
-        'env-vars': {}
+        'env_vars': {}
     }
 
     log.info('submitting %s', json.dumps(job_spec, indent=4, sort_keys=True))
@@ -48,7 +48,7 @@ def submit(experiment, image, cmd):
         headers={'content-type': 'application/json'}
     )
 
-    job_id = str(response.json()['job-id'])
+    job_id = str(response.json()['job_id'])
     return job_id
 
 


### PR DESCRIPTION
* Adds call to the job's log endpoint. Not connected to `yadage` yet.

* Fixes job controller API fields names according to last version.