### PR TITLE
installation: update to last `yadage` version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN dnf -y update && \
 ADD . /code
 WORKDIR /code
 RUN pip install --upgrade pip && \
-    pip install -e .[all]
+    pip install -e .
 ARG QUEUE_ENV=default
 ENV QUEUE_ENV ${QUEUE_ENV}
 ENV PYTHONPATH=/workdir

--- a/reana_workflow_engine_yadage/tasks.py
+++ b/reana_workflow_engine_yadage/tasks.py
@@ -27,8 +27,8 @@ import os
 from glob import glob
 
 import zmq
-from yadage.clihelpers import setupbackend_fromstring
 from yadage.steering_api import steering_ctx
+from yadage.utils import setupbackend_fromstring
 
 import reana_workflow_engine_yadage.celery_zeromq
 from reana_workflow_engine_yadage.celeryapp import app
@@ -59,10 +59,16 @@ def run_yadage_workflow_standalone(workflow_uuid, ctx):
 
     cap_backend = setupbackend_fromstring('fromenv')
 
-    with steering_ctx(workdir=analysis_workspace,
-                      workflow=ctx['workflow'],
-                      loadtoplevel=ctx['toplevel'],
+    with steering_ctx(dataarg=analysis_workspace,
+                      workflow_json=ctx['workflow'],  # FIXME `workflow_json`
+                                                      # only valid for
+                                                      # workflow files,
+                                                      # use `workflow` when
+                                                      # workflow file name
+                                                      # provided.
+                      toplevel=ctx['toplevel'],
                       initdata=ctx['preset_pars'],
+                      visualize=False,
                       updateinterval=5,
                       loginterval=5,
                       backend=cap_backend) as ys:

--- a/reana_workflow_engine_yadage/zeromq_tracker.py
+++ b/reana_workflow_engine_yadage/zeromq_tracker.py
@@ -22,7 +22,7 @@
 
 import json
 
-from yadage.helpers import WithJsonRefEncoder
+from yadage.utils import WithJsonRefEncoder
 
 
 class ZeroMQTracker(object):

--- a/setup.py
+++ b/setup.py
@@ -65,10 +65,10 @@ install_requires = [
     'celery==3.1.17',
     'pyzmq==16.0.2',
     'requests==2.11.1',
-    'yadage-schemas==0.6.0',
-    'adage==0.7.1',
-    'packtivity==0.5.18',
-    'yadage-fork==0.10.8',
+    'yadage-schemas==0.7.4',
+    'adage==0.8.2',
+    'packtivity==0.8.8',
+    'yadage==0.12.13',
 ]
 
 packages = find_packages()


### PR DESCRIPTION
* Since `yadage` 0.12.13 workflow file submission is supported so
  no need to have `yadage-fork` anymore.

Signed-off-by: Diego Rodriguez <diego.rodriguez@cern.ch>