### PR TITLE
config: set canonical location to read inputs

### DIFF
--- a/reana_workflow_engine_yadage/config.py
+++ b/reana_workflow_engine_yadage/config.py
@@ -24,6 +24,9 @@
 
 import os
 
+INPUTS_DIRECTORY_RELATIVE_PATH = 'inputs'
+"""Represents the relative path to the inputs directory (populated by RWC)"""
+
 SHARED_VOLUME = os.getenv('SHARED_VOLUME', '/reana/default')
 """Path to the mounted REANA shared volume."""
 

--- a/reana_workflow_engine_yadage/tasks.py
+++ b/reana_workflow_engine_yadage/tasks.py
@@ -31,6 +31,7 @@ from yadage.utils import setupbackend_fromstring
 
 import reana_workflow_engine_yadage.celery_zeromq
 from reana_workflow_engine_yadage.celeryapp import app
+from reana_workflow_engine_yadage.config import INPUTS_DIRECTORY_RELATIVE_PATH
 from reana_workflow_engine_yadage.database import load_session
 from reana_workflow_engine_yadage.models import Workflow, WorkflowStatus
 from reana_workflow_engine_yadage.zeromq_tracker import ZeroMQTracker
@@ -84,8 +85,14 @@ def run_yadage_workflow(workflow_uuid, workflow_workspace,
         # i.e. github:reanahub/reana-demo-root6-roofit/workflow.yaml
         workflow_kwargs = dict(workflow=workflow, toplevel=toplevel)
 
+    # Set `workflow_workspace/inputs_directory_relative_path` as the input
+    # directory
+    dataops = {'initdir': os.path.join(workflow_workspace,
+                                       INPUTS_DIRECTORY_RELATIVE_PATH)}
+
     try:
         with steering_ctx(dataarg=workflow_workspace,
+                          dataops=dataops,
                           initdata=parameters if parameters else {},
                           visualize=False,
                           updateinterval=5,


### PR DESCRIPTION
* (closes #38).

Signed-off-by: Diego Rodriguez <diego.rodriguez@cern.ch>