### PR TITLE
global: declare queues in message broker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,12 +23,16 @@ RUN dnf -y update && \
     dnf install -y gcc gcc-c++ graphviz-devel ImageMagick python-devel libffi-devel openssl openssl-devel openssh-clients unzip nano autoconf automake libtool python-pip git &&\
     dnf install -y dnf redhat-rpm-config
 
-RUN pip install git+git://github.com/reanahub/reana-commons.git@master#egg=reana-commons
+RUN pip install --upgrade pip && \
+    pip install git+git://github.com/reanahub/reana-commons.git@master#egg=reana-commons
 
 ADD . /code
 WORKDIR /code
-RUN pip install --upgrade pip && \
-    pip install -e .
+
+# Debug off by default
+ARG DEBUG=false
+
+RUN if [ "${DEBUG}" = "true" ]; then pip install -r requirements-dev.txt; pip install -e .[all]; else pip install .[all]; fi;
 
 ARG QUEUE_ENV=default
 ENV QUEUE_ENV ${QUEUE_ENV}

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,9 @@ RUN if [ "${DEBUG}" = "true" ]; then pip install -r requirements-dev.txt; pip in
 
 ARG QUEUE_ENV=default
 ENV QUEUE_ENV ${QUEUE_ENV}
+ARG CELERY_CONCURRENCY=2
+ENV CELERY_CONCURRENCY ${CELERY_CONCURRENCY}
 ENV PYTHONPATH=/workdir
 ENV PACKTIVITY_ASYNCBACKEND reana_workflow_engine_yadage.externalbackend:ExternalBackend:ExternalProxy
-CMD celery -A reana_workflow_engine_yadage.celeryapp worker -l info -Q ${QUEUE_ENV}
+
+CMD celery -A reana_workflow_engine_yadage.celeryapp worker -l info -Q ${QUEUE_ENV} --concurrency ${CELERY_CONCURRENCY}

--- a/reana_workflow_engine_yadage/celeryapp.py
+++ b/reana_workflow_engine_yadage/celeryapp.py
@@ -26,7 +26,6 @@ from celery import Celery
 
 from .config import BROKER
 
-
 app = Celery('tasks',
              broker=BROKER,
              include=['reana_workflow_engine_yadage.tasks'])

--- a/reana_workflow_engine_yadage/celeryapp.py
+++ b/reana_workflow_engine_yadage/celeryapp.py
@@ -26,6 +26,7 @@ from celery import Celery
 
 from .config import BROKER
 
+
 app = Celery('tasks',
              broker=BROKER,
              include=['reana_workflow_engine_yadage.tasks'])

--- a/reana_workflow_engine_yadage/config.py
+++ b/reana_workflow_engine_yadage/config.py
@@ -46,5 +46,15 @@ SHARED_VOLUME_PATH = os.getenv('SHARED_VOLUME_PATH', '/reana/default')
 JOBCONTROLLER_HOST = os.getenv('JOBCONTROLLER_HOST',
                                'job-controller.default.svc.cluster.local')
 
-BROKER = os.getenv('RABBIT_MQ', 'amqp://test:1234@'
-                   'message-broker.default.svc.cluster.local//')
+BROKER_URL = os.getenv('RABBIT_MQ_URL',
+                       'message-broker.default.svc.cluster.local')
+
+BROKER_PORT = os.getenv('RABBIT_MQ_PORT', 5672)
+
+BROKER_USER = os.getenv('RABBIT_MQ_USER', 'test')
+
+BROKER_PASS = os.getenv('RABBIT_MQ_PASS', '1234')
+
+BROKER = os.getenv('RABBIT_MQ', 'amqp://{0}:{1}@{2}//'.format(BROKER_USER,
+                                                              BROKER_PASS,
+                                                              BROKER_URL))

--- a/reana_workflow_engine_yadage/externalbackend.py
+++ b/reana_workflow_engine_yadage/externalbackend.py
@@ -129,7 +129,6 @@ class ExternalBackend(object):
         )
 
     def ready(self, resultproxy):
-        print('got:', submit.check_status(resultproxy.job_id))
         return submit.check_status(
             resultproxy.job_id)['job']['status'] != 'started'
 

--- a/reana_workflow_engine_yadage/externalbackend.py
+++ b/reana_workflow_engine_yadage/externalbackend.py
@@ -129,10 +129,13 @@ class ExternalBackend(object):
         )
 
     def ready(self, resultproxy):
-        return submit.check_status(resultproxy.job_id)['status'] != 'started'
+        print('got:', submit.check_status(resultproxy.job_id))
+        return submit.check_status(
+            resultproxy.job_id)['job']['status'] != 'started'
 
     def successful(self, resultproxy):
-        return submit.check_status(resultproxy.job_id)['status'] == 'succeeded'
+        return submit.check_status(
+            resultproxy.job_id)['job']['status'] == 'succeeded'
 
     def fail_info(self, resultproxy):
         pass

--- a/reana_workflow_engine_yadage/tasks.py
+++ b/reana_workflow_engine_yadage/tasks.py
@@ -167,7 +167,7 @@ def run_yadage_workflow(workflow_uuid, workflow_workspace,
             WorkflowStatus.failed,
             message=str(e))
     finally:
-        db_session.close()
+        db_session.remove()
         yadage_workflow_workspace_content = \
             os.path.join(workflow_workspace, '*')
         absolute_outputs_directory_path = os.path.join(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 wdb
 ipdb
 Flask-DebugToolbar
-git+git://github.com/reanahub/reana-commons.git#egg=reana-commons
+git+git://github.com/reanahub/reana-commons.git@master#egg=reana-commons

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ install_requires = [
     'packtivity==0.10.0',
     'yadage==0.13.5',
     'reana-commons>=0.1.0',
+    'pika==0.11.2',
 ]
 
 packages = find_packages()


### PR DESCRIPTION
* Publishes workflow status to message broker instead of accessing the DB.

(Should be merged after https://github.com/reanahub/reana-workflow-engine-yadage/pull/63)

Signed-off-by: Dinos Kousidis <dinos.kousidis@cern.ch>