### PR TITLE
installation: more version limits

### DIFF
--- a/reana_workflow_engine_yadage/version.py
+++ b/reana_workflow_engine_yadage/version.py
@@ -28,4 +28,4 @@ by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.3.0"
+__version__ = "0.3.1.dev20180905"

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup_requires = [
 
 install_requires = [
     'adage==0.8.5',
-    'celery>=4.2.1',
+    'celery>=4.2.1,<4.3',
     'enum34>=1.1.6',
     'packtivity==0.10.0',
     'pika>=0.12.0',


### PR DESCRIPTION
* Introduces more upper boundary limits for selected important
  dependencies (Bravado, Celery) for the cluster components.
  (addresses reanahub/reana#80)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>