### PR TITLE
publisher: improve error reporting

### DIFF
--- a/reana_workflow_engine_yadage/externalbackend.py
+++ b/reana_workflow_engine_yadage/externalbackend.py
@@ -20,7 +20,7 @@ from packtivity.syncbackends import (build_job, contextualize_parameters,
 from reana_commons.api_client import JobControllerAPIClient as rjc_api_client
 
 from .celeryapp import app
-from .utils import publisher
+from .utils import REANAWorkflowStatusPublisher
 
 log = logging.getLogger('yadage.cap.externalproxy')
 
@@ -124,6 +124,7 @@ class ExternalBackend(object):
             metadata['name'],)
 
         log.info('submitted job: %s', job_id)
+        publisher = REANAWorkflowStatusPublisher()
         publisher.publish_workflow_status(
             os.getenv('workflow_uuid', 'default'), 1,
             message={"job_id": str(job_id).decode('utf-8')})

--- a/reana_workflow_engine_yadage/externalbackend.py
+++ b/reana_workflow_engine_yadage/externalbackend.py
@@ -124,10 +124,23 @@ class ExternalBackend(object):
             metadata['name'],)
 
         log.info('submitted job: %s', job_id)
-        publisher = REANAWorkflowStatusPublisher()
-        publisher.publish_workflow_status(
-            os.getenv('workflow_uuid', 'default'), 1,
-            message={"job_id": str(job_id).decode('utf-8')})
+        message = {"job_id": str(job_id).decode('utf-8')}
+        workflow_uuid = os.getenv('workflow_uuid', 'default')
+        status_running = 1
+        try:
+            publisher = REANAWorkflowStatusPublisher()
+            publisher.publish_workflow_status(
+                workflow_uuid, status_running,
+                message=message)
+        except Exception as e:
+            log.info('Status: workflow - {workflow_uuid} '
+                     'status - {status} message - {message}'.format(
+                         workflow_uuid=workflow_uuid,
+                         status=status_running,
+                         message=message
+                     ))
+            log.info('workflow status publish failed: {0}'.format(e))
+
         return ExternalProxy(
             job_id=str(job_id),
             spec=spec,

--- a/reana_workflow_engine_yadage/tasks.py
+++ b/reana_workflow_engine_yadage/tasks.py
@@ -96,4 +96,9 @@ def run_yadage_workflow(workflow_uuid,
                      workflow_workspace=workflow_workspace))
     except Exception as e:
         log.info('workflow failed: {0}'.format(e))
-        publisher.publish_workflow_status(workflow_uuid, 3)
+        if publisher:
+            publisher.publish_workflow_status(workflow_uuid, 3)
+        else:
+            log.error('Workflow {workflow_uuid} failed but status '
+                      'could not be published.'.format(
+                          workflow_uuid=workflow_uuid))

--- a/reana_workflow_engine_yadage/tasks.py
+++ b/reana_workflow_engine_yadage/tasks.py
@@ -20,7 +20,7 @@ from yadage.utils import setupbackend_fromstring
 
 from .config import SHARED_VOLUME_PATH
 from .tracker import REANATracker
-from .utils import publisher
+from .utils import REANAWorkflowStatusPublisher
 
 log = logging.getLogger(__name__)
 
@@ -71,6 +71,7 @@ def run_yadage_workflow(workflow_uuid,
 
     dataopts = {'initdir': workflow_workspace}
     try:
+        publisher = REANAWorkflowStatusPublisher()
         with steering_ctx(dataarg=workflow_workspace,
                           dataopts=dataopts,
                           initdata=workflow_parameters if workflow_parameters

--- a/reana_workflow_engine_yadage/tracker.py
+++ b/reana_workflow_engine_yadage/tracker.py
@@ -18,7 +18,7 @@ import jq
 import networkx as nx
 from yadage.utils import WithJsonRefEncoder
 
-from .utils import publisher
+from .utils import REANAWorkflowStatusPublisher
 
 log = logging.getLogger(__name__)
 
@@ -117,6 +117,7 @@ class REANATracker(object):
                     {}
                     '''.format(self.workflow_id,
                                json.dumps(progress, indent=4), log_message))
+        publisher = REANAWorkflowStatusPublisher()
         publisher.publish_workflow_status(
             self.workflow_id, status=1, logs=log_message,
             message={"progress": progress})

--- a/reana_workflow_engine_yadage/utils.py
+++ b/reana_workflow_engine_yadage/utils.py
@@ -11,4 +11,15 @@ import json
 
 from reana_commons.publisher import WorkflowStatusPublisher
 
-publisher = WorkflowStatusPublisher()
+
+class REANAWorkflowStatusPublisher(object):
+    """REANA workflow status publisher singleton."""
+
+    __instance = None
+
+    def __new__(cls):
+        """REANA workflow status publisher object creation."""
+        if REANAWorkflowStatusPublisher.__instance is None:
+            REANAWorkflowStatusPublisher.__instance = \
+                WorkflowStatusPublisher()
+        return REANAWorkflowStatusPublisher.__instance

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ install_requires = [
     'packtivity==0.10.0',
     'pyzmq==16.0.2',
     'pyOpenSSL==17.5.0',  # FIXME remove once yadage-schemas solves deps.
-    'reana-commons>=0.5.0.dev20181126,<0.6.0',
+    'reana-commons>=0.5.0.dev20190122,<0.6.0',
     'requests==2.20.0',
     'rfc3987==1.3.7',  # FIXME remove once yadage-schemas solves deps.
     'strict-rfc3339==0.7',  # FIXME remove once yadage-schemas solves deps.


### PR DESCRIPTION
* Centralises the initialisation of WorkflowStatusPublisher
  using a Singleton to facilitate debugging and error reporting.

* This work needs to be completed but paves the way for improving
  error reporting for workflow engines on publishing errors
  (connects reanahub/reana-workflow-controller#172).