### PR TITLE
global: removal of r-w-monitor and zeromq

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ history = open('CHANGES.rst').read()
 tests_require = [
     'check-manifest>=0.25',
     'coverage>=4.0',
-    'isort>=4.2.9',
+    'isort>=4.2.2,<4.3',
     'pydocstyle>=1.0.0',
     'pytest-cache>=1.0',
     'pytest-cov>=1.8.0',
@@ -53,7 +53,6 @@ install_requires = [
     'click>=7,<8',
     'enum34>=1.1.6',
     'packtivity==0.10.0',
-    'pyzmq==16.0.2',
     'pyOpenSSL==17.5.0',  # FIXME remove once yadage-schemas solves deps.
     'reana-commons[kubernetes]>=0.5.0.dev20190220,<0.6.0',
     'requests==2.20.0',


### PR DESCRIPTION
* Removes r-w-monitor and zeromq cluster components that were not used since
  many moons. Helps to make the cluster slimmer and faster.
  (connects reanahub/reana-cluster#169)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>