### PR TITLE
externalbackend: pass workflow uuid for R-J-C

### DIFF
--- a/reana_workflow_engine_yadage/externalbackend.py
+++ b/reana_workflow_engine_yadage/externalbackend.py
@@ -116,7 +116,9 @@ class ExternalBackend(object):
 
         log.info('submitting!')
 
+        workflow_uuid = os.getenv('workflow_uuid', 'default')
         job_request_body = [
+            workflow_uuid,
             os.getenv('REANA_WORKFLOW_ENGINE_YADAGE_EXPERIMENT', 'default'),
             image,
             wrapped_cmd,

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ install_requires = [
     'enum34>=1.1.6',
     'packtivity==0.10.0',
     'pyOpenSSL==17.5.0',  # FIXME remove once yadage-schemas solves deps.
-    'reana-commons[kubernetes]>=0.5.0.dev20190322,<0.6.0',
+    'reana-commons[kubernetes]>=0.5.0.dev20190402,<0.6.0',
     'requests==2.20.0',
     'rfc3987==1.3.7',  # FIXME remove once yadage-schemas solves deps.
     'strict-rfc3339==0.7',  # FIXME remove once yadage-schemas solves deps.


### PR DESCRIPTION
* To enable cache R-J-C needs workflow uuid for getting
  workspace path.
  Connects reanahub/reana-job-controller/issues/118

Signed-off-by: Rokas Maciulaitis <rokas.maciulaitis@cern.ch>