### PR TITLE
tasks: adds connectivity to job controller check

### DIFF
--- a/reana_workflow_engine_yadage/tasks.py
+++ b/reana_workflow_engine_yadage/tasks.py
@@ -16,6 +16,7 @@ import os
 
 import click
 from reana_commons.config import REANA_LOG_FORMAT, REANA_LOG_LEVEL
+from reana_commons.utils import check_connection_to_job_controller
 from yadage.steering_api import steering_ctx
 from yadage.utils import setupbackend_fromstring
 
@@ -73,6 +74,7 @@ def run_yadage_workflow(workflow_uuid,
 
     dataopts = {'initdir': workflow_workspace}
     try:
+        check_connection_to_job_controller()
         publisher = REANAWorkflowStatusPublisher()
         with steering_ctx(dataarg=workflow_workspace,
                           dataopts=dataopts,

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ install_requires = [
     'enum34>=1.1.6',
     'packtivity==0.10.0',
     'pyOpenSSL==17.5.0',  # FIXME remove once yadage-schemas solves deps.
-    'reana-commons>=0.5.0,<0.6.0',
+    'reana-commons>=0.6.0.dev20190619,<0.7.0',
     'requests==2.20.0',
     'rfc3987==1.3.7',  # FIXME remove once yadage-schemas solves deps.
     'strict-rfc3339==0.7',  # FIXME remove once yadage-schemas solves deps.


### PR DESCRIPTION
* When job controller and workflow engines run in the same pod,
  workflow engine has to ensure that job controller is ready to
  receive requests.
  Connects reanahub/reana-job-controller/issues/105

Signed-off-by: Rokas Maciulaitis <rokas.maciulaitis@cern.ch>