### PR TITLE
yadage: fix image tag support

### DIFF
--- a/reana_workflow_engine_yadage/externalbackend.py
+++ b/reana_workflow_engine_yadage/externalbackend.py
@@ -82,7 +82,9 @@ class ExternalBackend(object):
             wrapped_cmd = make_script(job)
 
         image = spec['environment']['image']
-        # tag = spec['environment']['imagetag']
+        imagetag = spec['environment'].get('imagetag', '')
+        if imagetag:
+            image = image + ":" + imagetag
 
         kerberos = None
         compute_backend = None


### PR DESCRIPTION
* Fixes support for specifying wanted image tag in Yadage workflow
  definition files. (closes #143)

Signed-off-by: Tibor Šimko <tibor.simko@cern.ch>