### PR TITLE
Operational options: add initfiles

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -3,6 +3,7 @@ Authors
 
 The list of contributors in alphabetical order:
 
+- `Adelina Lintuluoto <https://orcid.org/0000-0002-0726-1452>`_
 - `Daniel Prelipcean <https://orcid.org/0000-0002-4855-194X>`_
 - `Diego Rodriguez <https://orcid.org/0000-0003-0649-2002>`_
 - `Dinos Kousidis <https://orcid.org/0000-0002-4914-4289>`_

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Version master (UNRELEASED)
 - Performs workflow specification load logic. Before in ``reana-client``.
 - Adds VOMS proxy support as a new authentication method.
 - Add Black formatter support.
+- Adds initfiles as an operational option for Yadage.
 
 Version 0.6.1 (2020-05-25)
 --------------------------

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ install_requires = [
     "yadage==0.20.1",
     "yadage-schemas==0.10.6",
     "webcolors==1.9.1",  # FIXME remove once yadage-schemas solves yadage deps.
+    "checksumdir>=1.1.4,<1.2",
 ]
 
 packages = find_packages()


### PR DESCRIPTION
Add operational option `initfiles` that people can use in their reana.yaml, similarly to the options initdir and toplevel. `initfiles` expects an array of files to read the input parameters from.

Example

```
inputs:
  options:
    initfiles: 
      - workflow/yadage/input_filenames.yml
      - workflow/yadage/input_cross_sections.yml
```

closes reanahub/reana#305