### PR TITLE
migrate to python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache:
   - pip
 
 python:
-  - "3.6"
+  - "3.8"
 
 services:
   - docker

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 Version master (UNRELEASED)
 ---------------------------
 
+- Uses python3.8
 - Pins all Python dependencies allowing to easily rebuild component images at later times.
 - Upgrades to Yadage 0.20.1.
 - Creates workflow visualisation graph by default.

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 
 # Install base image and its dependencies
-FROM python:3.6-slim
+FROM python:3.8-slim
 RUN apt-get update && \
     apt-get install -y \
       autoconf \

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,18 +10,16 @@ attrs==19.3.0             # via jsonschema
 bravado-core==5.17.0      # via bravado
 bravado==10.3.2           # via reana-commons
 certifi==2020.6.20        # via requests
-cffi==1.14.0              # via cryptography
+cffi==1.14.1              # via cryptography
 chardet==3.0.4            # via requests
-checksumdir==1.1.9        # via packtivity, reana-commons, yadage
+checksumdir==1.1.9        # via packtivity, reana-commons, reana-workflow-engine-yadage (setup.py), yadage
 click==7.1.2              # via packtivity, reana-commons, reana-workflow-engine-yadage (setup.py), yadage, yadage-schemas
-cryptography==2.9.2       # via pyopenssl, requests
+cryptography==3.0         # via pyopenssl, requests
 decorator==4.4.2          # via jsonpath-rw, networkx
-enum34==1.1.10            # via reana-workflow-engine-yadage (setup.py)
 glob2==0.7                # via packtivity, yadage
-graphviz==0.14            # via reana-workflow-engine-yadage (setup.py)
+graphviz==0.14.1          # via reana-workflow-engine-yadage (setup.py)
 idna==2.8                 # via jsonschema, requests
-importlib-metadata==1.7.0  # via jsonschema, kombu
-jq==0.1.6                 # via packtivity, reana-workflow-engine-yadage (setup.py), yadage
+jq==1.0.2                 # via packtivity, reana-workflow-engine-yadage (setup.py), yadage
 jsonpath-rw==1.4.0        # via packtivity, yadage
 jsonpointer==2.0          # via jsonschema, packtivity, yadage
 jsonref==0.2              # via bravado-core, packtivity, yadage, yadage-schemas
@@ -34,7 +32,7 @@ msgpack==1.0.0            # via bravado-core
 networkx==1.11            # via adage, reana-workflow-engine-yadage (setup.py)
 packtivity==0.14.21       # via reana-workflow-engine-yadage (setup.py), yadage
 ply==3.11                 # via jsonpath-rw
-psutil==5.7.0             # via packtivity, yadage
+psutil==5.7.2             # via packtivity, yadage
 pycparser==2.20           # via cffi
 pydot2==1.0.33            # via reana-workflow-engine-yadage (setup.py)
 pydotplus==2.0.2          # via reana-workflow-engine-yadage (setup.py)
@@ -45,23 +43,22 @@ pyrsistent==0.16.0        # via jsonschema
 python-dateutil==2.8.1    # via bravado, bravado-core
 pytz==2020.1              # via bravado-core
 pyyaml==5.3.1             # via bravado, bravado-core, packtivity, reana-commons, yadage, yadage-schemas
-reana-commons==0.7.0.dev20200625  # via reana-workflow-engine-yadage (setup.py)
+reana-commons==0.7.0a2    # via reana-workflow-engine-yadage (setup.py)
 requests[security]==2.22.0  # via bravado, packtivity, reana-workflow-engine-yadage (setup.py), yadage, yadage-schemas
 rfc3987==1.3.8            # via jsonschema, reana-workflow-engine-yadage (setup.py)
-simplejson==3.17.0        # via bravado, bravado-core
+simplejson==3.17.2        # via bravado, bravado-core
 six==1.15.0               # via bravado, bravado-core, cryptography, jsonpath-rw, jsonschema, pyopenssl, pyrsistent, python-dateutil, sqlalchemy-utils, webcolors
 sqlalchemy-utils==0.36.8  # via reana-workflow-engine-yadage (setup.py)
 sqlalchemy==1.3.18        # via reana-workflow-engine-yadage (setup.py), sqlalchemy-utils
 strict-rfc3339==0.7       # via jsonschema, reana-workflow-engine-yadage (setup.py)
 swagger-spec-validator==2.7.3  # via bravado-core
 typing-extensions==3.7.4.2  # via bravado
-urllib3==1.25.9           # via requests
+urllib3==1.25.10          # via requests
 vine==1.3.0               # via amqp
 webcolors==1.9.1          # via jsonschema, reana-workflow-engine-yadage (setup.py)
 werkzeug==1.0.1           # via reana-commons
 yadage-schemas==0.10.6    # via packtivity, reana-workflow-engine-yadage (setup.py), yadage
 yadage==0.20.1            # via reana-workflow-engine-yadage (setup.py)
-zipp==3.1.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/setup.py
+++ b/setup.py
@@ -42,9 +42,8 @@ setup_requires = [
 install_requires = [
     "adage==0.10.1",  # FIXME remove once yadage-schemas solves yadage deps.
     "click>=7",
-    "enum34>=1.1.6",
     "graphviz>=0.12",  # FIXME needed only if yadage visuale=True.
-    "jq==0.1.6",
+    "jq>=0.1.7",
     "networkx==1.11",
     "packtivity==0.14.21",
     "pydot2>=1.0.33",  # FIXME needed only if yadage visuale=True.
@@ -98,10 +97,8 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python",
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",


### PR DESCRIPTION
Closes reanahub/reana#352

Package `enum34` is not compatible with Python 3.6 and later versions. Is not needed in the code so I removed it from `setup.py`.