### PR TITLE
setup: fix bsm example slowness

### DIFF
--- a/reana_workflow_engine_yadage/version.py
+++ b/reana_workflow_engine_yadage/version.py
@@ -14,4 +14,4 @@ by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.7.0a1"
+__version__ = "0.7.0a2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ decorator==4.4.2          # via jsonpath-rw, networkx
 glob2==0.7                # via packtivity, yadage
 graphviz==0.14.1          # via reana-workflow-engine-yadage (setup.py)
 idna==2.8                 # via jsonschema, requests
-jq==1.0.2                 # via packtivity, reana-workflow-engine-yadage (setup.py), yadage
+jq==0.1.7                 # via packtivity, reana-workflow-engine-yadage (setup.py), yadage
 jsonpath-rw==1.4.0        # via packtivity, yadage
 jsonpointer==2.0          # via jsonschema, packtivity, yadage
 jsonref==0.2              # via bravado-core, packtivity, yadage, yadage-schemas

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ install_requires = [
     "adage==0.10.1",  # FIXME remove once yadage-schemas solves yadage deps.
     "click>=7",
     "graphviz>=0.12",  # FIXME needed only if yadage visuale=True.
-    "jq>=0.1.7",
+    "jq==0.1.7",
     "networkx==1.11",
     "packtivity==0.14.21",
     "pydot2>=1.0.33",  # FIXME needed only if yadage visuale=True.


### PR DESCRIPTION
closes reanahub/reana-demo-bsm-search#21

[`jq` was hard-pinned](https://github.com/reanahub/reana-workflow-engine-yadage/commit/5307900773116a69e48a19d921d2b39437eb1baf#diff-2eeaed663bd0d25b7e608891384b7298L47) in the past, perhaps for a reason.

Steps:
```console
$ cd ../reana-workflow-engine-yadage
$ gh pr checkout 161
$ reana-dev docker-build -b DEBUG=1 -c reana-workflow-engine-yadage --no-cache
$ reana-dev kind-load-docker-image -c reana-workflow-engine-yadage
$ reana-dev python-install-eggs
$ reana-dev cluster-undeploy
$ reana-dev cluster-deploy --mode debug --admin-email jdoe@example.org --admin-password 123456 --exclude-components r-ui
$ eval $(reana-dev client-setup-environment)
$ reana-client ping
$ cd ../reana-demo-bsm-search
$ reana-client run -w bsm
...
$ reana-client status -w bsm
NAME   RUN_NUMBER   CREATED               STARTED               ENDED                 STATUS     PROGRESS
bsm    1            2020-09-22T08:17:31   2020-09-22T08:17:32   2020-09-22T08:23:27   finished   67/65
```