### PR TITLE
Add accept_metadir

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 Version 0.7.0 (2020-10-20)
 --------------------------
 
+- Allows restarting of yadage workflows.
 - Adds creation of workflow visualisation graph by default when a workflow runs.
 - Adds option to specify unpacked Docker images as workflow step requirement.
 - Adds handling of workflow specification load logic that was done before in ``reana-client``.

--- a/reana_workflow_engine_yadage/cli.py
+++ b/reana_workflow_engine_yadage/cli.py
@@ -146,6 +146,7 @@ def run_yadage_workflow(
             updateinterval=5,
             loginterval=5,
             backend=cap_backend,
+            accept_metadir="accept_metadir" in operational_options,
             **workflow_kwargs,
         ) as ys:
 


### PR DESCRIPTION
Add `accept_metadir` to allow overwriting the yadage meta directory `_yadage` that exist if you restart a workflow in yadage workspace.

closes reanahub/reana-server#293