### PR TITLE
global: handle termination signals

### DIFF
--- a/reana_workflow_engine_yadage/cli.py
+++ b/reana_workflow_engine_yadage/cli.py
@@ -9,13 +9,10 @@
 
 from __future__ import absolute_import, print_function
 
-import base64
-import json
 import logging
 import os
 import yaml
 
-import click
 import yadageschemas
 from reana_commons.config import (
     REANA_LOG_FORMAT,
@@ -23,7 +20,7 @@ from reana_commons.config import (
     REANA_WORKFLOW_UMASK,
     SHARED_VOLUME_PATH,
 )
-from reana_commons.utils import check_connection_to_job_controller
+from reana_commons.workflow_engine import create_workflow_engine_command
 from yadage.steering_api import steering_ctx
 from yadage.utils import setupbackend_fromstring
 
@@ -35,63 +32,15 @@ logging.basicConfig(level=REANA_LOG_LEVEL, format=REANA_LOG_FORMAT)
 log = logging.getLogger(LOGGING_MODULE)
 
 
-def load_json(ctx, param, value):
-    """Decode and load json for click option."""
-    value = value[1:]
-    return json.loads(base64.standard_b64decode(value).decode())
-
-
-def load_yadage_operational_options(ctx, param, operational_options):
-    """Decode and prepare operational options."""
-    operational_options = load_json(ctx, param, operational_options)
-    workflow_workspace = ctx.params.get("workflow_workspace")
-    workflow_workspace = "{0}/{1}".format(SHARED_VOLUME_PATH, workflow_workspace)
-    toplevel = operational_options.get("toplevel", "")
-    if not toplevel.startswith("github:"):
-        toplevel = os.path.join(workflow_workspace, toplevel)
-    operational_options["toplevel"] = toplevel
-
-    operational_options["initdir"] = os.path.join(
-        workflow_workspace, operational_options.get("initdir", "")
-    )
-
-    operational_options["initfiles"] = [
-        os.path.join(workflow_workspace, initfile)
-        for initfile in operational_options.get("initfiles", [])
-    ]
-
-    return operational_options
-
-
-@click.command()
-@click.option("--workflow-uuid", required=True, help="UUID of workflow to be run.")
-@click.option(
-    "--workflow-workspace",
-    required=True,
-    help="Name of workspace in which workflow should run.",
-)
-@click.option(
-    "--workflow-file",
-    required=True,
-    help="Path to the workflow file. This field is used when"
-    " no workflow JSON has been passed.",
-)
-@click.option(
-    "--workflow-parameters",
-    help="JSON representation of workflow_parameters received by" " the workflow.",
-    callback=load_json,
-)
-@click.option(
-    "--operational-options",
-    help="Options to be passed to the workflow engine" " (e.g. initdir).",
-    callback=load_yadage_operational_options,
-)
-def run_yadage_workflow(
-    workflow_uuid,
-    workflow_workspace,
-    workflow_file,
+def run_yadage_workflow_engine_adapter(
+    publisher,
+    rjc_api_client,
+    workflow_uuid=None,
+    workflow_workspace=None,
+    workflow_file=None,
     workflow_parameters=None,
     operational_options={},
+    **kwargs,
 ):
     """Run a ``yadage`` workflow."""
     log.info("getting socket..")
@@ -103,76 +52,55 @@ def run_yadage_workflow(
 
     cap_backend = setupbackend_fromstring("fromenv")
     workflow_file_abs_path = os.path.join(workflow_workspace, workflow_file)
-    publisher = REANAWorkflowStatusPublisher()
-    try:
-        if not os.path.exists(workflow_file_abs_path):
-            message = f"Workflow file {workflow_file} does not exist"
-            raise Exception(message)
-        else:
-            schema_name = "yadage/workflow-schema"
-            schemadir = None
-            specopts = {
-                "toplevel": operational_options["toplevel"],
-                "schema_name": schema_name,
-                "schemadir": schemadir,
-                "load_as_ref": False,
-            }
+    publisher = REANAWorkflowStatusPublisher(instance=publisher)
+    if not os.path.exists(workflow_file_abs_path):
+        message = f"Workflow file {workflow_file} does not exist"
+        raise Exception(message)
+    else:
+        schema_name = "yadage/workflow-schema"
+        schemadir = None
+        specopts = {
+            "toplevel": operational_options["toplevel"],
+            "schema_name": schema_name,
+            "schemadir": schemadir,
+            "load_as_ref": False,
+        }
 
-            validopts = {
-                "schema_name": schema_name,
-                "schemadir": schemadir,
-            }
-            workflow_json = yadageschemas.load(
-                spec=workflow_file,
-                specopts=specopts,
-                validopts=validopts,
-                validate=True,
-            )
-            workflow_kwargs = dict(workflow_json=workflow_json)
-        dataopts = {"initdir": operational_options["initdir"]}
-
-        initdata = {}
-        for initfile in operational_options["initfiles"]:
-            initdata.update(**yaml.safe_load(open(initfile)))
-        initdata.update(workflow_parameters)
-
-        check_connection_to_job_controller()
-
-        with steering_ctx(
-            dataarg=workflow_workspace,
-            dataopts=dataopts,
-            initdata=initdata,
-            visualize=True,
-            updateinterval=5,
-            loginterval=5,
-            backend=cap_backend,
-            accept_metadir="accept_metadir" in operational_options,
-            **workflow_kwargs,
-        ) as ys:
-
-            log.info("running workflow on context: {0}".format(locals()))
-            publisher.publish_workflow_status(workflow_uuid, 1)
-
-            ys.adage_argument(
-                additional_trackers=[REANATracker(identifier=workflow_uuid)]
-            )
-
-        publisher.publish_workflow_status(workflow_uuid, 2)
-
-        log.info(
-            "Workflow {workflow_uuid} finished. Files available "
-            "at {workflow_workspace}.".format(
-                workflow_uuid=workflow_uuid, workflow_workspace=workflow_workspace
-            )
+        validopts = {
+            "schema_name": schema_name,
+            "schemadir": schemadir,
+        }
+        workflow_json = yadageschemas.load(
+            spec=workflow_file, specopts=specopts, validopts=validopts, validate=True,
         )
-    except Exception as e:
-        log.error("Workflow failed: {0}".format(e), exc_info=True)
-        if publisher:
-            publisher.publish_workflow_status(
-                workflow_uuid, 3, logs="workflow failed: {0}".format(e)
-            )
-        else:
-            log.error(
-                "Workflow {workflow_uuid} failed but status "
-                "could not be published.".format(workflow_uuid=workflow_uuid)
-            )
+        workflow_kwargs = dict(workflow_json=workflow_json)
+    dataopts = {"initdir": operational_options["initdir"]}
+
+    initdata = {}
+    for initfile in operational_options["initfiles"]:
+        initdata.update(**yaml.safe_load(open(initfile)))
+    initdata.update(workflow_parameters)
+
+    with steering_ctx(
+        dataarg=workflow_workspace,
+        dataopts=dataopts,
+        initdata=initdata,
+        visualize=True,
+        updateinterval=5,
+        loginterval=5,
+        backend=cap_backend,
+        accept_metadir="accept_metadir" in operational_options,
+        **workflow_kwargs,
+    ) as ys:
+
+        log.info("running workflow on context: {0}".format(locals()))
+        publisher.publish_workflow_status(workflow_uuid, 1)
+
+        ys.adage_argument(additional_trackers=[REANATracker(identifier=workflow_uuid)])
+
+    publisher.publish_workflow_status(workflow_uuid, 2)
+
+
+run_yadage_workflow = create_workflow_engine_command(
+    run_yadage_workflow_engine_adapter, engine_type="yadage"
+)

--- a/reana_workflow_engine_yadage/utils.py
+++ b/reana_workflow_engine_yadage/utils.py
@@ -15,8 +15,10 @@ class REANAWorkflowStatusPublisher(object):
 
     __instance = None
 
-    def __new__(cls):
+    def __new__(cls, instance=None):
         """REANA workflow status publisher object creation."""
-        if REANAWorkflowStatusPublisher.__instance is None:
+        if instance:
+            REANAWorkflowStatusPublisher.__instance = instance
+        elif REANAWorkflowStatusPublisher.__instance is None:
             REANAWorkflowStatusPublisher.__instance = WorkflowStatusPublisher()
         return REANAWorkflowStatusPublisher.__instance

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ pyrsistent==0.17.3        # via jsonschema
 python-dateutil==2.8.1    # via bravado, bravado-core
 pytz==2020.1              # via bravado-core
 pyyaml==5.3.1             # via bravado, bravado-core, packtivity, reana-commons, yadage, yadage-schemas
-reana-commons==0.7.2      # via reana-workflow-engine-yadage (setup.py)
+reana-commons==0.7.3      # via reana-workflow-engine-yadage (setup.py)
 requests[security]==2.22.0  # via bravado, packtivity, reana-workflow-engine-yadage (setup.py), yadage, yadage-schemas
 rfc3987==1.3.8            # via jsonschema, reana-workflow-engine-yadage (setup.py)
 simplejson==3.17.2        # via bravado, bravado-core

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ install_requires = [
     "pydotplus>=2.0.2",  # FIXME needed only if yadage visuale=True.
     "pygraphviz>=1.5",  # FIXME needed only if yadage visuale=True.
     "pyOpenSSL==19.0.0",  # FIXME remove once yadage-schemas solves deps.
-    "reana-commons>=0.7.2,<0.8.0",
+    "reana-commons>=0.7.3,<0.8.0",
     "requests==2.22.0",
     "rfc3987==1.3.8",  # FIXME remove once yadage-schemas solves yadage deps.
     "strict-rfc3339==0.7",  # FIXME remove once yadage-schemas solves deps.


### PR DESCRIPTION
* Uses REANA-Commons decorator to handle termination signals in the
  workflow engine container by notifying the system about the failure
  and registering the workflow as failed.

Addresses reanahub/reana#478