### PR TITLE
global: rename job status succeeded

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+Version 0.7.3 (UNRELEASED)
+--------------------------
+
+- Changes workflow engine instantiation to use central REANA-Commons factory.
+
 Version 0.7.2 (2021-02-03)
 --------------------------
 

--- a/reana_workflow_engine_yadage/externalbackend.py
+++ b/reana_workflow_engine_yadage/externalbackend.py
@@ -185,7 +185,7 @@ class ExternalBackend(object):
 
     def successful(self, resultproxy):
         """Check if the packtivity was successful."""
-        return self._get_state(resultproxy) == "succeeded"
+        return self._get_state(resultproxy) == "finished"
 
     def fail_info(self, resultproxy):
         """Retrieve the fail info."""

--- a/reana_workflow_engine_yadage/tracker.py
+++ b/reana_workflow_engine_yadage/tracker.py
@@ -41,7 +41,7 @@ def analyze_progress(adageobj):
             )
         elif dagstate.node_status(nodeobj):
             nodestates.append(
-                {"state": "succeeded", "job_id": nodeobj.resultproxy.jobproxy["job_id"]}
+                {"state": "finished", "job_id": nodeobj.resultproxy.jobproxy["job_id"]}
             )
         elif dagstate.node_ran_and_failed(nodeobj):
             nodestates.append(
@@ -94,7 +94,7 @@ class REANATracker(object):
         for node in analyze_progress(adageobj):
             key = {
                 "running": "running",
-                "succeeded": "finished",
+                "finished": "finished",
                 "failed": "failed",
                 "unsubmittable": "planned",
                 "scheduled": "total",


### PR DESCRIPTION
* Renames ``succeeded`` to ``finished`` as the latter is the one
  described centrally in ``reana_db.models.WorkflowStatus`` and
  ``reana_db.models.JobStatus``.