### PR TITLE
global: harmonise job command treatment

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Version 0.7.3 (UNRELEASED)
 --------------------------
 
 - Changes workflow engine instantiation to use central REANA-Commons factory.
+- Changes job command strings by removing interpreter when possible and using central REANA-Commons job command serialisation.
 
 Version 0.7.2 (2021-02-03)
 --------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ pyrsistent==0.17.3        # via jsonschema
 python-dateutil==2.8.1    # via bravado, bravado-core
 pytz==2020.1              # via bravado-core
 pyyaml==5.3.1             # via bravado, bravado-core, packtivity, reana-commons, yadage, yadage-schemas
-reana-commons==0.7.3      # via reana-workflow-engine-yadage (setup.py)
+reana-commons==0.7.4      # via reana-workflow-engine-yadage (setup.py)
 requests[security]==2.22.0  # via bravado, packtivity, reana-workflow-engine-yadage (setup.py), yadage, yadage-schemas
 rfc3987==1.3.8            # via jsonschema, reana-workflow-engine-yadage (setup.py)
 simplejson==3.17.2        # via bravado, bravado-core

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ readme = open("README.rst").read()
 history = open("CHANGES.rst").read()
 
 tests_require = [
-    "pytest-reana>=0.7.0,<0.8.0",
+    "pytest-reana>=0.7.1,<0.8.0",
 ]
 
 extras_require = {
@@ -50,7 +50,7 @@ install_requires = [
     "pydotplus>=2.0.2",  # FIXME needed only if yadage visuale=True.
     "pygraphviz>=1.5",  # FIXME needed only if yadage visuale=True.
     "pyOpenSSL==19.0.0",  # FIXME remove once yadage-schemas solves deps.
-    "reana-commons>=0.7.3,<0.8.0",
+    "reana-commons>=0.7.4,<0.8.0",
     "requests==2.22.0",
     "rfc3987==1.3.8",  # FIXME remove once yadage-schemas solves yadage deps.
     "strict-rfc3339==0.7",  # FIXME remove once yadage-schemas solves deps.


### PR DESCRIPTION
* Let `JobControllerAPIClient` take care of serialisation internally
  (through `reana_commons.job_utils.serialise_job_command`).

Closes reanahub/reana-job-controller#304.