### PR TITLE
installation: remove legacy sqlalchemy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 REANA-Workflow-Engine-Yadage
 ############################
 
-. image:: https://github.com/reanahub/reana-workflow-engine-yadage/workflows/CI/badge.svg
+.. image:: https://github.com/reanahub/reana-workflow-engine-yadage/workflows/CI/badge.svg
       :target: https://github.com/reanahub/reana-workflow-engine-yadage/actions
 
 .. image:: https://readthedocs.org/projects/reana-workflow-engine-yadage/badge/?version=latest

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,9 +47,7 @@ reana-commons==0.7.4      # via reana-workflow-engine-yadage (setup.py)
 requests[security]==2.22.0  # via bravado, packtivity, reana-workflow-engine-yadage (setup.py), yadage, yadage-schemas
 rfc3987==1.3.8            # via jsonschema, reana-workflow-engine-yadage (setup.py)
 simplejson==3.17.2        # via bravado, bravado-core
-six==1.15.0               # via bravado, bravado-core, cryptography, jsonpath-rw, jsonschema, mock, pyopenssl, python-dateutil, sqlalchemy-utils, webcolors
-sqlalchemy-utils==0.36.8  # via reana-workflow-engine-yadage (setup.py)
-sqlalchemy==1.3.20        # via reana-workflow-engine-yadage (setup.py), sqlalchemy-utils
+six==1.15.0               # via bravado, bravado-core, cryptography, fs, jsonpath-rw, jsonschema, mock, pyopenssl, python-dateutil, webcolors
 strict-rfc3339==0.7       # via jsonschema, reana-workflow-engine-yadage (setup.py)
 swagger-spec-validator==2.7.3  # via bravado-core
 typing-extensions==3.7.4.3  # via bravado

--- a/setup.py
+++ b/setup.py
@@ -54,8 +54,6 @@ install_requires = [
     "requests==2.22.0",
     "rfc3987==1.3.8",  # FIXME remove once yadage-schemas solves yadage deps.
     "strict-rfc3339==0.7",  # FIXME remove once yadage-schemas solves deps.
-    "SQLAlchemy-Utils>=0.32.18",
-    "SQLAlchemy>=1.1.14",
     "yadage==0.20.1",
     "yadage-schemas==0.10.6",
     "webcolors==1.9.1",  # FIXME remove once yadage-schemas solves yadage deps.


### PR DESCRIPTION
This PR removes `sqlalchemy` and `sqlalchemy-utils` from the list of project requirements. The list of `requirements.txt` has been updated accordingly.

### Issue
When running the project Python tests:
 ```
./run-tests.sh --check-pytest
```

They fail because of a version of _SQLAlchemy_ that _SQLAlchemy-utils_ do not support yet (version `1.4.0`+). They currently have an [open issue](https://github.com/kvesteri/sqlalchemy-utils/issues/505) about this, and I believe Diego [has already fix this in other REANA repos](https://github.com/reanahub/reana-db/commit/221ee727802988bc11b329a3dba96f47d701fdc2) (i.e. `reana-db`).

### Explanation
Same case as `reana-db`, this repository also contains _SQLAlchemy_ and _SQLAlchemy-utils_ as dependencies. So, in principle, the same patch would be required.

However, taking a look at what this repository accomplish, and taking a look at [the commit where these dependencies were introduced](https://github.com/reanahub/reana-workflow-engine-yadage/commit/32eec06214b720e1d3dfddb318d1dda420c01bd0) (2018), I believe they are now legacy, as the functionality requiring them has been moved to `reana-commons`.