### PR TITLE
publisher: fix progress update message

### DIFF
--- a/reana_workflow_engine_yadage/externalbackend.py
+++ b/reana_workflow_engine_yadage/externalbackend.py
@@ -15,6 +15,7 @@ import pipes
 from packtivity.asyncbackends import ExternalAsyncProxy
 from packtivity.syncbackends import build_job, finalize_inputs, packconfig, publish
 from reana_commons.api_client import JobControllerAPIClient as RJC_API_Client
+from reana_commons.utils import build_progress_message
 
 from .config import LOGGING_MODULE, MOUNT_CVMFS
 from .utils import REANAWorkflowStatusPublisher
@@ -140,7 +141,11 @@ class ExternalBackend(object):
         job_id = self.rjc_api_client.submit(**job_request_body)
 
         log.info("submitted job:{0}".format(job_id))
-        message = {"job_id": str(job_id)}
+        message = {
+            "progress": build_progress_message(
+                running={"total": 1, "job_ids": [job_id.get("job_id")]}
+            )
+        }
         workflow_uuid = os.getenv("workflow_uuid", "default")
         status_running = 1
         try:


### PR DESCRIPTION
* This message wasn't correctly formatted, therefore, RWC wasn't
  marking the job as started in the DB.

To test:

- You should run a Yadage workflow and see that the `Started` and `Finished` attributes are filled in `reana-client logs -w workflow-name`.

**Why was this happening?**

The [job status consumer in RWC](https://github.com/reanahub/reana-workflow-controller/blob/ae4f10e1daa942b4e02f65f58a7c879f3fb9529e/reana_workflow_controller/consumer.py#L50) wouldn't understand the malformed dictionary, because the keys do not comply with [what it expects](https://github.com/reanahub/reana-workflow-controller/blob/ae4f10e1daa942b4e02f65f58a7c879f3fb9529e/reana_workflow_controller/consumer.py#L175).

Errors like this are very dangerous and very difficult to spot. Perhaps a solution would be to perform validation on the outgoing data pushed to RabbitMQ, e.g. through Marshmallow.

Closes reanahub/reana-client#497.