### PR TITLE
cli: modify  workspace_path to store full path

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -5,6 +5,7 @@ The list of contributors in alphabetical order:
 
 - `Adelina Lintuluoto <https://orcid.org/0000-0002-0726-1452>`_
 - `Audrius Mecionis <https://orcid.org/0000-0002-3759-1663>`_
+- `Camila Diaz <https://orcid.org/0000-0001-5543-797X>`_
 - `Daniel Prelipcean <https://orcid.org/0000-0002-4855-194X>`_
 - `Diego Rodriguez <https://orcid.org/0000-0003-0649-2002>`_
 - `Dinos Kousidis <https://orcid.org/0000-0002-4914-4289>`_

--- a/reana_workflow_engine_yadage/cli.py
+++ b/reana_workflow_engine_yadage/cli.py
@@ -17,7 +17,6 @@ from reana_commons.config import (
     REANA_LOG_FORMAT,
     REANA_LOG_LEVEL,
     REANA_WORKFLOW_UMASK,
-    SHARED_VOLUME_PATH,
 )
 from reana_commons.workflow_engine import create_workflow_engine_command
 from yadage.steering_api import steering_ctx
@@ -43,7 +42,6 @@ def run_yadage_workflow_engine_adapter(
 ):
     """Run a ``yadage`` workflow."""
     log.info("getting socket..")
-    workflow_workspace = "{0}/{1}".format(SHARED_VOLUME_PATH, workflow_workspace)
     # use some shared object between tasks.
     os.environ["workflow_uuid"] = workflow_uuid
     os.environ["workflow_workspace"] = workflow_workspace

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ pyrsistent==0.17.3        # via jsonschema
 python-dateutil==2.8.1    # via bravado, bravado-core
 pytz==2021.1              # via bravado-core, fs
 pyyaml==5.4.1             # via bravado, bravado-core, packtivity, reana-commons, swagger-spec-validator, yadage, yadage-schemas
-reana-commons[yadage]==0.8.0a17  # via reana-workflow-engine-yadage (setup.py)
+reana-commons[yadage]==0.8.0a21  # via reana-workflow-engine-yadage (setup.py)
 requests[security]==2.25.1  # via bravado, packtivity, reana-workflow-engine-yadage (setup.py), yadage, yadage-schemas
 rfc3987==1.3.8            # via jsonschema, reana-workflow-engine-yadage (setup.py)
 simplejson==3.17.2        # via bravado, bravado-core

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ readme = open("README.rst").read()
 history = open("CHANGES.rst").read()
 
 tests_require = [
-    "pytest-reana>=0.8.0a5,<0.9.0",
+    "pytest-reana>=0.8.0a6,<0.9.0",
 ]
 
 extras_require = {
@@ -47,7 +47,7 @@ install_requires = [
     "pydot2>=1.0.33",  # FIXME needed only if yadage visuale=True.
     "pydotplus>=2.0.2",  # FIXME needed only if yadage visuale=True.
     "pygraphviz>=1.5",  # FIXME needed only if yadage visuale=True.
-    "reana-commons[yadage]>=0.8.0a17,<0.9.0",
+    "reana-commons[yadage]>=0.8.0a21,<0.9.0",
     "requests>=2.25.1",
     "rfc3987==1.3.8",  # FIXME remove once yadage-schemas solves yadage deps.
     "checksumdir>=1.1.4,<1.2",


### PR DESCRIPTION
Delete the dependency on SHARED_VOLUME_PATH by storing the full path inside the database, for serial, yadage and cwl engines.

Closes reanahub/reana-db#94