### PR TITLE
docker: pin base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 
 # Install base image and its dependencies
-FROM python:3.8-slim
+FROM python:3.8-slim-buster
 # hadolint ignore=DL3008, DL3013, DL3015
 RUN apt-get update && \
     apt-get install -y \


### PR DESCRIPTION
Fixes problem with `python-pip` package.

```console
docker build --no-cache -t reanahub/reana-workflow-engine-yadage:latest .
[+] Building 3.2s (6/13)                                                                                                                                                                                                                                                                                                    
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                                                   0.0s
 => => transferring dockerfile: 1.44kB                                                                                                                                                                                                                                                                                 0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                                                                      0.0s
 => => transferring context: 35B                                                                                                                                                                                                                                                                                       0.0s
 => [internal] load metadata for docker.io/library/python:3.8-slim                                                                                                                                                                                                                                                     0.0s
 => [internal] load build context                                                                                                                                                                                                                                                                                      0.0s
 => => transferring context: 14.13kB                                                                                                                                                                                                                                                                                   0.0s
 => CACHED [1/9] FROM docker.io/library/python:3.8-slim                                                                                                                                                                                                                                                                0.0s
 => ERROR [2/9] RUN apt-get update &&     apt-get install -y       autoconf       automake       gcc       graphviz       graphviz-dev       imagemagick       libffi-dev       libtool       openssl       python-dev       python-pip       unzip       vim-tiny &&       apt-get clean &&       rm -rf /var/lib/ap  3.1s
------                                                                                                                                                                                                                                                                                                                      
 > [2/9] RUN apt-get update &&     apt-get install -y       autoconf       automake       gcc       graphviz       graphviz-dev       imagemagick       libffi-dev       libtool       openssl       python-dev       python-pip       unzip       vim-tiny &&       apt-get clean &&       rm -rf /var/lib/apt/lists/* &&     pip install --upgrade pip:                                                                                                                                                                                                                                                                                               
#5 0.348 Get:1 http://deb.debian.org/debian bullseye InRelease [113 kB]                                                                                                                                                                                                                                                     
#5 0.348 Get:2 http://security.debian.org/debian-security bullseye-security InRelease [44.1 kB]                                                                                                                                                                                                                             
#5 0.407 Get:3 http://deb.debian.org/debian bullseye-updates InRelease [36.8 kB]                                                                                                                                                                                                                                            
#5 0.485 Get:4 http://security.debian.org/debian-security bullseye-security/main amd64 Packages [27.5 kB]
#5 0.601 Get:5 http://deb.debian.org/debian bullseye/main amd64 Packages [8178 kB]
#5 1.839 Fetched 8399 kB in 2s (5348 kB/s)
#5 1.839 Reading package lists...
#5 2.384 Reading package lists...
#5 2.857 Building dependency tree...
#5 2.974 Reading state information...
#5 3.005 Package python-pip is not available, but is referred to by another package.
#5 3.005 This may mean that the package is missing, has been obsoleted, or
#5 3.005 is only available from another source
#5 3.005 However the following packages replace it:
#5 3.005   python3-pip
#5 3.005 
#5 3.076 E: Package 'python-pip' has no installation candidate
------
executor failed running [/bin/sh -c apt-get update &&     apt-get install -y       autoconf       automake       gcc       graphviz       graphviz-dev       imagemagick       libffi-dev       libtool       openssl       python-dev       python-pip       unzip       vim-tiny &&       apt-get clean &&       rm -rf /var/lib/apt/lists/* &&     pip install --upgrade pip]: exit code: 100
```