### PR TITLE
yadage: reduce number of API calls to r-j-c

### DIFF
--- a/reana_workflow_engine_yadage/config.py
+++ b/reana_workflow_engine_yadage/config.py
@@ -9,7 +9,7 @@
 """REANA Workflow Engine Yadage config."""
 
 import os
-from enum import IntEnum
+from enum import IntEnum, Enum
 
 MOUNT_CVMFS = os.getenv("REANA_MOUNT_CVMFS", "false")
 
@@ -32,3 +32,22 @@ class RunStatus(IntEnum):
     stopped = 5
     queued = 6
     pending = 7
+
+
+# defined in reana-db component, in reana_db/models.py file as JobStatus
+class JobStatus(str, Enum):
+    """Enumeration of job statuses.
+
+    Example:
+        JobStatus.started == "started"  # True
+    """
+
+    # FIXME: this state is not defined in reana-db but returned by r-job-controller
+    started = "started"
+
+    created = "created"
+    running = "running"
+    finished = "finished"
+    failed = "failed"
+    stopped = "stopped"
+    queued = "queued"


### PR DESCRIPTION
- reduces the amount of API calls to r-j-c by checking only running jobs and ignoring finished or failed

### Testing

Decrease `WORKFLOW_TRACKING_UPDATE_INTERVAL_SECONDS` to 3 seconds. Run `recast-demo` with Yadage, observe logs from `job-controller`, a job that is finished is not queried by workflow-engine, only jobs that are not ready.
Previous behavior was the same as setting `should_refresh_job_status()` to return always True. In this case, the status of the finished jobs would still be queried.

Related #204