### PR TITLE
tracker: publish running status before Yadage init

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+Version 0.8.1 (UNRELEASED)
+---------------------------
+
+- Fixes workflow stuck in pending status due to early Yadage fail.
+
 Version 0.8.0 (2021-11-22)
 ---------------------------
 

--- a/reana_workflow_engine_yadage/cli.py
+++ b/reana_workflow_engine_yadage/cli.py
@@ -48,6 +48,9 @@ def run_yadage_workflow_engine_adapter(
     os.environ["workflow_workspace"] = workflow_workspace
     os.umask(REANA_WORKFLOW_UMASK)
 
+    tracker = REANATracker(identifier=workflow_uuid, publisher=publisher)
+    tracker.publish_workflow_running_status()
+
     cap_backend = setupbackend_fromstring("fromenv")
     workflow_kwargs = dict(workflow_json=workflow_json)
     dataopts = {"initdir": operational_options["initdir"]}
@@ -58,7 +61,6 @@ def run_yadage_workflow_engine_adapter(
             initdata.update(**yaml.safe_load(stream))
     initdata.update(workflow_parameters)
 
-    tracker = REANATracker(identifier=workflow_uuid, publisher=publisher)
     with steering_ctx(
         dataarg=workflow_workspace,
         dataopts=dataopts,
@@ -74,8 +76,8 @@ def run_yadage_workflow_engine_adapter(
 
         ys.adage_argument(additional_trackers=[tracker])
 
-    # Hack to publish finished workflow status AFTER visualization is done.
-    tracker._publish_workflow_final_status()
+    # hack to publish finished workflow status AFTER Yadage visualization is done.
+    tracker.publish_workflow_final_status()
 
 
 run_yadage_workflow = create_workflow_engine_command(

--- a/reana_workflow_engine_yadage/tracker.py
+++ b/reana_workflow_engine_yadage/tracker.py
@@ -65,14 +65,26 @@ class REANATracker:
         # needed to comment it here due to a hack in cli.py
         # self._publish_workflow_final_status()
 
-    def _publish_workflow_final_status(self):
+    def publish_workflow_running_status(self) -> None:
+        """Send MQ to indicate running status for tracked workflow."""
+        try:
+            log.debug("Publishing workflow running status...")
+            self.publisher.publish_workflow_status(
+                self.workflow_id, status=int(RunStatus.running)
+            )
+        except Exception as e:
+            log.error(f"Workflow running status publish failed: {e}")
+            raise e
+
+    def publish_workflow_final_status(self) -> None:
+        """Send MQ to indicate finished or failed status for the tracked workflow."""
         if self._workflow_failed():
-            log.info("Workflow failed. Publishing...")
+            log.info("Workflow failed. Publishing status...")
             self.publisher.publish_workflow_status(
                 self.workflow_id, int(RunStatus.failed)
             )
         else:
-            log.info("Workflow finished. Publishing...")
+            log.info("Workflow finished. Publishing status...")
             self.publisher.publish_workflow_status(
                 self.workflow_id, int(RunStatus.finished)
             )

--- a/reana_workflow_engine_yadage/tracker.py
+++ b/reana_workflow_engine_yadage/tracker.py
@@ -9,7 +9,7 @@
 
 import json
 import logging
-from typing import NoReturn, Dict, Generator
+from typing import Dict, Generator
 
 import adage.dagstate as dagstate
 import adage.nodestate as nodestate
@@ -33,14 +33,14 @@ class REANATracker:
         self.publisher = publisher
         self.progress_state = self._build_init_progress_state()
 
-    def initialize(self, adageobj) -> NoReturn:
+    def initialize(self, adageobj) -> None:
         """Get the progress state when workflow starts.
 
         Method is called by Yadage package in the beginning of the workflow execution.
         """
         self.track(adageobj)
 
-    def track(self, adageobj) -> NoReturn:
+    def track(self, adageobj) -> None:
         """Get the progress state of the workflow and publish it if changed.
 
         Method is periodically called by Yadage package during the workflow execution,
@@ -53,7 +53,7 @@ class REANATracker:
             log.debug("track, workflow's progress state changed. Updating...")
             self._update_progress_state(current_progress_state)
 
-    def finalize(self, adageobj) -> NoReturn:
+    def finalize(self, adageobj) -> None:
         """Update the progress state at the end of the execution.
 
         Method is called at the end of Yadage workflow execution.
@@ -110,7 +110,7 @@ class REANATracker:
     def _workflow_failed(self) -> bool:
         return self.progress_state.get("failed", {}).get("total", -1) != 0
 
-    def _publish_progress(self):
+    def _publish_progress(self) -> None:
         message = {"progress": self.progress_state}
         status_running = int(RunStatus.running)
         try:
@@ -149,7 +149,7 @@ class REANATracker:
         progress["engine_specific"] = self._dump_workflow_dag(adageobj)
         return progress
 
-    def _update_progress_state(self, progress: Dict) -> NoReturn:
+    def _update_progress_state(self, progress: Dict) -> None:
         self.progress_state = progress
         self._publish_progress()
 


### PR DESCRIPTION
- removes case when Yadage engine fails before running status is published leaving workflow in pending state.
- one additional MQ message is sent at the beginning of each Yadage workflow.

closes #216

How to test:

You can pretty much the scenario described in the issue. Details:

1. Go to `helloworld` workflow demo. Edit parameters in `reana-yadage.yaml` to be incorrect. For example, changing `sleeptime` to `sleept`;

2. Run the workflows, `reana-client run -w yadage -f reana-yadage.yaml`;

3. Workflow should fail.