### PR TITLE
add kubernetes_job_timeout parameter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 Version 0.8.1 (UNRELEASED)
 ---------------------------
 
+- Adds support for specifying ``kubernetes_job_timeout`` for Kubernetes compute backend jobs.
 - Fixes workflow stuck in pending status due to early Yadage fail.
 
 Version 0.8.0 (2021-11-22)

--- a/tests/test_externalbackend.py
+++ b/tests/test_externalbackend.py
@@ -1,0 +1,38 @@
+# This file is part of REANA.
+# Copyright (C) 2021 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""REANA-Workflow-Engine-Yadage ExternalBackend tests."""
+
+from typing import List, Dict, Any, Union
+
+import pytest
+
+
+class TestExternalBackend:
+    @pytest.mark.parametrize(
+        "input_parameters,final_parameters",
+        [
+            (
+                [
+                    {"compute_backend": "kubernetes"},
+                    {"not_exists": "value"},
+                    {"kubernetes_job_timeout": 20},
+                    {"kubernetes_memory_limit": None},
+                ],
+                {"compute_backend": "kubernetes", "kubernetes_job_timeout": 20},
+            ),
+            (
+                [{"kubernetes_job_timeout": 10}, {"kubernetes_job_timeout": 30}],
+                {"kubernetes_job_timeout": 30},
+            ),
+        ],
+    )
+    def test_get_resources(
+        self, input_parameters: List[Union[Dict, Any]], final_parameters: Dict[str, Any]
+    ):
+        from reana_workflow_engine_yadage.externalbackend import ExternalBackend
+
+        assert ExternalBackend._get_resources(input_parameters) == final_parameters


### PR DESCRIPTION
closes reanahub/reana-job-controller#343

How to test:

This PR is part of a bigger group of PRs. Please refer to the addressed issue to see all of them.

1. Modify Yadage helloworld example, with `kubernetes_job_timeout=20` (in seconds) and `sleeptime=2` (2 seconds so the workflow will definitely run longer than 20 seconds):

`reana-yadage.yml`
```yaml
...
parameters:
    sleeptime: 2  # <= here
    inputfile: data/names.txt
    helloworld: code/helloworld.py
...
```

`workflow/yadage/workflow.yaml`
```yaml
...
environment:
          environment_type: 'docker-encapsulated'
          image: 'python'
          imagetag: '2.7-slim'
          resources:
            - kubernetes_job_timeout: 20  # <= here
...
```

2. Start workflow `reana-client run -w yadage-timeout -f reana-yadage.yaml`

3. After 25-30 seconds, check using `reana-client list` if workflow failed. It should.

4. Using `reana-client logs -w yadage-timeout` check if the reason is `Job was killed due to timeout.`

5. Try to input string or object instead of integer for `kubernetes_job_timeout`, the workflow should fail with an error message like:

```
('Error while marshalling value=not_correct_timeout to type=integer/int32.', ValueError("invalid literal for int() with base 10: 'not_correct_timeout'"))
```

Check it using `reana-client logs`.

**Note:** You will see an error message above, but you will not see engine logs in the `reana-client logs` output. This is due to [this issue](https://github.com/reanahub/reana-workflow-controller/issues/426). It will be fixed after this PR.
