### PR TITLE
docker: adapt to latest python:3.8-slim-buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2019, 2020, 2021 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -18,8 +18,8 @@ RUN apt-get update && \
       libffi-dev \
       libtool \
       openssl \
-      python-dev \
-      python-pip \
+      python3-dev \
+      python3-pip \
       unzip \
       vim-tiny && \
       apt-get clean && \


### PR DESCRIPTION
When building the image with latest `python:3.8-slim-buster`, the build
times were unusually slow because some of the dependencies wanted to
bring over Python 2 instead of Python 3 libraries. This commit fixes the
problem and makes the build process fast again.

(However, Python 3.7 system packages are still being brought, which is
inconsistent with Python 3.8 version that the image provides. An upgrade
to Python 3.9 or a replacement of the base image may be wanted soon.)