### PR TITLE
add global Kerberos propagation 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 Version 0.9.0 (UNRELEASED)
 ---------------------------
 
+- Adds support for propagating global Kerberos flag from workflow specification to each job.
 - Adds support for specifying ``slurm_partition`` and ``slurm_time`` for Slurm compute backend jobs.
 
 Version 0.8.2 (2022-02-08)

--- a/reana_workflow_engine_yadage/config.py
+++ b/reana_workflow_engine_yadage/config.py
@@ -8,6 +8,7 @@
 
 """REANA Workflow Engine Yadage config."""
 
+from distutils.util import strtobool
 import os
 from enum import IntEnum, Enum
 
@@ -18,6 +19,9 @@ LOGGING_MODULE = "reana-workflow-engine-yadage"
 WORKFLOW_TRACKING_UPDATE_INTERVAL_SECONDS = 15
 
 LOG_INTERVAL_SECONDS = 15
+
+WORKFLOW_KERBEROS = bool(strtobool(os.getenv("REANA_WORKFLOW_KERBEROS", "false")))
+"""Whether Kerberos is needed for the whole workflow."""
 
 
 # defined in reana-db component, in reana_db/models.py file as RunStatus

--- a/reana_workflow_engine_yadage/externalbackend.py
+++ b/reana_workflow_engine_yadage/externalbackend.py
@@ -14,7 +14,7 @@ from packtivity.asyncbackends import ExternalAsyncProxy
 from packtivity.syncbackends import build_job, finalize_inputs, packconfig, publish
 from reana_commons.api_client import JobControllerAPIClient as RJC_API_Client
 
-from .config import LOGGING_MODULE, MOUNT_CVMFS, JobStatus
+from .config import LOGGING_MODULE, MOUNT_CVMFS, JobStatus, WORKFLOW_KERBEROS
 
 log = logging.getLogger(LOGGING_MODULE)
 
@@ -81,6 +81,10 @@ class ExternalBackend:
             set_parameter(item, "htcondor_accounting_group")
             set_parameter(item, "slurm_partition")
             set_parameter(item, "slurm_time")
+
+        if "kerberos" not in parameters:
+            parameters["kerberos"] = WORKFLOW_KERBEROS
+
         return parameters
 
     def submit(  # noqa: C901

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ pyrsistent==0.18.1        # via jsonschema
 python-dateutil==2.8.2    # via bravado, bravado-core
 pytz==2022.1              # via bravado-core, fs
 pyyaml==5.4.1             # via bravado, bravado-core, packtivity, reana-commons, yadage, yadage-schemas
-reana-commons[yadage]==0.9.0a7  # via reana-workflow-engine-yadage (setup.py)
+reana-commons[yadage]==0.9.0a9	# via reana-workflow-engine-yadage (setup.py)
 requests[security]==2.27.1  # via bravado, packtivity, reana-workflow-engine-yadage (setup.py), yadage, yadage-schemas
 rfc3987==1.3.8            # via jsonschema, reana-workflow-engine-yadage (setup.py)
 simplejson==3.17.6        # via bravado, bravado-core

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ readme = open("README.rst").read()
 history = open("CHANGES.rst").read()
 
 tests_require = [
-    "pytest-reana>=0.9.0a4,<0.10.0",
+    "pytest-reana>=0.9.0a5,<0.10.0",
 ]
 
 extras_require = {
@@ -61,7 +61,7 @@ install_requires = [
     "adage==0.10.1",  # FIXME remove once yadage>=0.20.2 is compatible.
     "yadage==0.20.1",  # FIXME remove once yadage>=0.20.2 is compatible.
     "yadage-schemas==0.10.6",  # FIXME remove once yadage>=0.20.2 is compatible.
-    "reana-commons[yadage]>=0.9.0a7,<0.10.0",
+    "reana-commons[yadage]>=0.9.0a9,<0.10.0",
     "requests>=2.25.1",
     "rfc3987==1.3.8",  # FIXME remove once yadage-schemas solves yadage deps.
 ]

--- a/tests/test_externalbackend.py
+++ b/tests/test_externalbackend.py
@@ -22,11 +22,19 @@ class TestExternalBackend:
                     {"kubernetes_job_timeout": 20},
                     {"kubernetes_memory_limit": None},
                 ],
-                {"compute_backend": "kubernetes", "kubernetes_job_timeout": 20},
+                {
+                    "compute_backend": "kubernetes",
+                    "kubernetes_job_timeout": 20,
+                    "kerberos": False,
+                },
             ),
             (
                 [{"kubernetes_job_timeout": 10}, {"kubernetes_job_timeout": 30}],
-                {"kubernetes_job_timeout": 30},
+                {"kubernetes_job_timeout": 30, "kerberos": False},
+            ),
+            (
+                [{"kerberos": True}],
+                {"kerberos": True},
             ),
         ],
     )


### PR DESCRIPTION
closes #231 

How to test:

```diff
diff --git a/reana-yadage.yaml b/reana-yadage.yaml
index d00859b..41f1834 100644
--- a/reana-yadage.yaml
+++ b/reana-yadage.yaml
@@ -11,6 +11,8 @@ inputs:
     helloworld: code/helloworld.py
 workflow:
   type: yadage
+  resources:
+    kerberos: true
   file: workflow/yadage/workflow.yaml
 outputs:
   files:
```

```diff
diff --git a/workflow/yadage/workflow.yaml b/workflow/yadage/workflow.yaml
index 16bc4a5..0222902 100644
--- a/workflow/yadage/workflow.yaml
+++ b/workflow/yadage/workflow.yaml
@@ -25,12 +25,12 @@ stages:
       step:
         process:
           process_type: 'string-interpolated-cmd'
-          cmd: 'python "{helloworld}" --sleeptime {sleeptime} --inputfile "{inputfile}" --outputfile "{
outputfile}"'
+          cmd: 'klist 2>&1; exit 0'
         publisher:
           publisher_type: 'frompar-pub'
           outputmap:
             outputfile: outputfile
         environment:
           environment_type: 'docker-encapsulated'
-          image: 'python'
-          imagetag: '2.7-slim'
+          image: 'reanahub/krb5'
+          imagetag: 'latest'
```