### PR TITLE
installation: upgrade jq dependency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+Version 0.9.2 (UNRELEASED)
+--------------------------
+
+- Fixes container image building on the arm64 architecture.
+
 Version 0.9.1 (2023-09-27)
 --------------------------
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,8 +1,8 @@
 # This file is part of REANA.
-# Copyright (C) 2020, 2022 CERN.
+# Copyright (C) 2020, 2022, 2023 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-jq==0.1.7
+jq==1.4.1
 pygraphviz==1.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ fs==2.4.16                # via reana-commons
 glob2==0.7                # via packtivity, yadage
 graphviz==0.20.1          # via reana-workflow-engine-yadage (setup.py)
 idna==3.4                 # via jsonschema, requests
-jq==0.1.7                 # via -r requirements.in, packtivity, yadage
+jq==1.4.1                 # via -r requirements.in, packtivity, yadage
 jsonpath-rw==1.4.0        # via packtivity, yadage
 jsonpointer==2.4          # via jsonschema, packtivity, yadage
 jsonref==1.1.0            # via bravado-core, packtivity, yadage, yadage-schemas

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -34,7 +34,7 @@ extras_require = {
     ],
     "tests": tests_require,
     "jq": [
-        "jq==0.1.7",
+        "jq==1.4.1",
     ],
     "pygraphviz": [
         "pygraphviz>=1.5",


### PR DESCRIPTION
Upgrades `jq` Python dependency, fixing the container image building process on the arm64 architecture.

Closes reanahub/reana#753.