### PR TITLE
installation: faster jq on amd64

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+Version 0.9.3 (UNRELEASED)
+--------------------------
+
+- Changes `jq` dependency version on amd64 architecture to older version, making certain Yadage workflows much faster.
+
 Version 0.9.2 (2023-12-12)
 --------------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changes
 =======
 
-Version 0.9.3 (UNRELEASED)
+Version 0.9.3 (2023-12-14)
 --------------------------
 
 - Changes `jq` dependency version on amd64 architecture to older version, making certain Yadage workflows much faster.

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ ENV PACKTIVITY_ASYNCBACKEND=reana_workflow_engine_yadage.externalbackend:Externa
 
 # Set image labels
 LABEL org.opencontainers.image.authors="team@reanahub.io"
-LABEL org.opencontainers.image.created="2023-12-12"
+LABEL org.opencontainers.image.created="2023-12-14"
 LABEL org.opencontainers.image.description="REANA reproducible analysis platform - Yadage workflow engine component"
 LABEL org.opencontainers.image.documentation="https://reana-workflow-engine-yadage.readthedocs.io/"
 LABEL org.opencontainers.image.licenses="MIT"
@@ -82,4 +82,4 @@ LABEL org.opencontainers.image.source="https://github.com/reanahub/reana-workflo
 LABEL org.opencontainers.image.title="reana-workflow-engine-yadage"
 LABEL org.opencontainers.image.url="https://github.com/reanahub/reana-workflow-engine-yadage"
 LABEL org.opencontainers.image.vendor="reanahub"
-LABEL org.opencontainers.image.version="0.9.2"
+LABEL org.opencontainers.image.version="0.9.3"

--- a/reana_workflow_engine_yadage/version.py
+++ b/reana_workflow_engine_yadage/version.py
@@ -14,4 +14,4 @@ by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.9.2"
+__version__ = "0.9.3"

--- a/requirements.in
+++ b/requirements.in
@@ -4,5 +4,7 @@
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-jq==1.4.1
+jq==0.1.7; platform_machine == "x86_64"
+jq==1.4.1; platform_machine == "aarch4"
+jq==1.4.1; platform_machine == "arm64"
 pygraphviz==1.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ adage==0.10.1             # via reana-commons, reana-workflow-engine-yadage (set
 amqp==5.2.0               # via kombu
 appdirs==1.4.4            # via fs
 attrs==23.1.0             # via jsonschema
-backports-zoneinfo[tzdata]==0.2.1  # via backports-zoneinfo, kombu
+backports-zoneinfo[tzdata]==0.2.1  # via kombu
 bracex==2.4               # via wcmatch
 bravado==10.3.2           # via reana-commons
 bravado-core==6.1.0       # via bravado
@@ -21,7 +21,9 @@ fs==2.4.16                # via reana-commons
 glob2==0.7                # via packtivity, yadage
 graphviz==0.20.1          # via reana-workflow-engine-yadage (setup.py)
 idna==3.6                 # via jsonschema, requests
-jq==1.4.1                 # via -r requirements.in, packtivity, yadage
+jq==0.1.7 ; platform_machine == "x86_64"  # via -r requirements.in, packtivity, yadage
+jq==1.4.1 ; platform_machine == "aarch64"  # via -r requirements.in, packtivity, yadage
+jq==1.4.1 ; platform_machine == "arm64"  # via -r requirements.in, packtivity, yadage
 jsonpath-rw==1.4.0        # via packtivity, yadage
 jsonpointer==2.4          # via jsonschema, packtivity, yadage
 jsonref==1.1.0            # via bravado-core, packtivity, yadage, yadage-schemas
@@ -44,7 +46,7 @@ pyrsistent==0.20.0        # via jsonschema
 python-dateutil==2.8.2    # via bravado, bravado-core
 pytz==2023.3.post1        # via bravado-core
 pyyaml==6.0.1             # via bravado, bravado-core, packtivity, reana-commons, swagger-spec-validator, yadage, yadage-schemas
-reana-commons[yadage]==0.9.4  # via reana-commons, reana-workflow-engine-yadage (setup.py)
+reana-commons[yadage]==0.9.4  # via reana-workflow-engine-yadage (setup.py)
 requests[security]==2.31.0  # via bravado, bravado-core, packtivity, reana-workflow-engine-yadage (setup.py), yadage, yadage-schemas
 rfc3987==1.3.8            # via jsonschema, reana-workflow-engine-yadage (setup.py)
 simplejson==3.19.2        # via bravado, bravado-core

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,11 @@ extras_require = {
         "sphinx-rtd-theme>=0.1.9",
     ],
     "tests": tests_require,
+    # Using older jq on amd64 due to https://github.com/reanahub/reana-demo-bsm-search/issues/21
     "jq": [
-        "jq==1.4.1",
+        "jq==0.1.7; platform_machine == 'x86_64'",
+        "jq==1.4.1; platform_machine == 'aarch4'",
+        "jq==1.4.1; platform_machine == 'arm64'",
     ],
     "pygraphviz": [
         "pygraphviz>=1.5",


### PR DESCRIPTION
Changes `jq` dependency version on amd64 architecture to older version, making certain Yadage workflows much faster.

Closes reanahub/reana-demo-bsm-search#21