### PR TITLE
fix(tracker): remove invalid `planned` state (#268)

### DIFF
--- a/reana_workflow_engine_yadage/tracker.py
+++ b/reana_workflow_engine_yadage/tracker.py
@@ -92,7 +92,6 @@ class REANATracker:
     @staticmethod
     def _build_init_progress_state() -> Dict:
         return {
-            "planned": {"total": 0, "job_ids": []},
             "failed": {"total": 0, "job_ids": []},
             "total": {"total": 0, "job_ids": []},
             "running": {"total": 0, "job_ids": []},
@@ -176,9 +175,6 @@ class REANATracker:
             elif dagstate.node_ran_and_failed(nodeobj):
                 state = "failed"
                 job_id = nodeobj.resultproxy.jobproxy["job_id"]
-            elif dagstate.upstream_failure(dag, nodeobj):
-                state = "planned"
-                job_id = None
             else:
                 state = "total"
                 job_id = None

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -15,11 +15,8 @@ from unittest.mock import MagicMock
 import pytest
 
 
-def _build_progress_state(
-    planned: int, total: int, failed: int, running: int, finished: int
-):
+def _build_progress_state(total: int, failed: int, running: int, finished: int):
     return {
-        "planned": {"total": planned},
         "total": {"total": total},
         "failed": {"total": failed},
         "running": {"total": running},
@@ -32,18 +29,18 @@ class TestReanaTracker:
         "prev_progress,next_progress,is_progressed",
         [
             (
-                _build_progress_state(0, 0, 0, 0, 0),
-                _build_progress_state(0, 0, 0, 0, 0),
+                _build_progress_state(0, 0, 0, 0),
+                _build_progress_state(0, 0, 0, 0),
                 False,
             ),
             (
-                _build_progress_state(0, 0, 0, 0, 0),
-                _build_progress_state(0, 2, 0, 0, 0),
+                _build_progress_state(0, 0, 0, 0),
+                _build_progress_state(2, 0, 0, 0),
                 True,
             ),
             (
-                _build_progress_state(0, 0, 2, 0, 0),
-                _build_progress_state(0, 0, 2, 1, 0),
+                _build_progress_state(0, 2, 0, 0),
+                _build_progress_state(0, 2, 1, 0),
                 True,
             ),
         ],
@@ -62,11 +59,11 @@ class TestReanaTracker:
         "progress,is_failed",
         [
             (
-                _build_progress_state(0, 2, 0, 0, 2),
+                _build_progress_state(2, 0, 0, 2),
                 False,
             ),
             (
-                _build_progress_state(0, 2, 1, 1, 0),
+                _build_progress_state(2, 1, 1, 0),
                 True,
             ),
             ({"failed": {"wrong_key": 0}}, True),


### PR DESCRIPTION
The `planned` status is not defined or used anywhere in REANA and it was
simply ignored.

Closes #255
