### PR TITLE
deprecations setuptools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update -y && \
       python3-pip \
       unzip \
       vim-tiny && \
-    pip install --no-cache-dir --upgrade pip setuptools && \
+    pip install --no-cache-dir --upgrade pip 'setuptools<71' && \
     pip install --no-cache-dir -r /code/requirements.txt && \
     apt-get remove -y \
       autoconf \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+# This file is part of REANA.
+# Copyright (C) 2024 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -55,7 +55,7 @@ check_sphinx () {
 }
 
 check_pytest () {
-    python setup.py test
+    pytest
 }
 
 check_dockerfile () {

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,9 +4,6 @@
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-[aliases]
-test = pytest
-
 [build_sphinx]
 source-dir = docs/
 build-dir = docs/_build

--- a/setup.py
+++ b/setup.py
@@ -51,11 +51,6 @@ for key, reqs in extras_require.items():
         continue
     extras_require["all"].extend(reqs)
 
-
-setup_requires = [
-    "pytest-runner>=2.7",
-]
-
 install_requires = [
     "graphviz>=0.12",  # FIXME needed only if yadage visuale=True.
     "pydot>=1.0.29",  # FIXME needed only if yadage visuale=True.
@@ -102,7 +97,6 @@ setup(
     },
     python_requires=">=3.8",
     extras_require=extras_require,
-    setup_requires=setup_requires,
     tests_require=tests_require,
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -18,10 +18,6 @@ from setuptools import find_packages, setup
 readme = open("README.md").read()
 history = open("CHANGELOG.md").read()
 
-tests_require = [
-    "pytest-reana>=0.95.0a2,<0.96.0",
-]
-
 extras_require = {
     "debug": [
         "wdb",
@@ -33,7 +29,9 @@ extras_require = {
         "Sphinx>=1.5.1",
         "sphinx-rtd-theme>=0.1.9",
     ],
-    "tests": tests_require,
+    "tests": [
+        "pytest-reana>=0.95.0a2,<0.96.0",
+    ],
     # Using older jq on amd64 due to https://github.com/reanahub/reana-demo-bsm-search/issues/21
     "jq": [
         "jq==0.1.7; platform_machine == 'x86_64'",
@@ -97,7 +95,6 @@ setup(
     },
     python_requires=">=3.8",
     extras_require=extras_require,
-    tests_require=tests_require,
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Environment :: Web Environment",


### PR DESCRIPTION
- **ci(pytest): invoke `pytest` directly instead of `setup.py test` (#272)**
- **build(python): remove deprecated `pytest-runner` (#272)**
- **build(python): use optional deps instead of `tests_require` (#272)**
- **build(python): add minimal `pyproject.toml` (#272)**
- **build(docker): pin setuptools to v70 (#272)**

Closes https://github.com/reanahub/reana/issues/814