### PR TITLE
build(python): use jq 1.2.2 on aarch64/arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2020, 2021, 2022, 2024 CERN.
+# Copyright (C) 2020, 2021, 2022, 2024, 2025 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -10,7 +10,7 @@ on: [push, pull_request]
 
 jobs:
   lint-commitlint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -36,7 +36,7 @@ jobs:
           ./run-tests.sh --check-commitlint ${{ github.event.pull_request.head.sha }}~${{ github.event.pull_request.commits }} ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.number }}
 
   lint-shellcheck:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -47,7 +47,7 @@ jobs:
           ./run-tests.sh --check-shellcheck
 
   lint-black:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -64,7 +64,7 @@ jobs:
           ./run-tests.sh --check-black
 
   lint-flake8:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -81,7 +81,7 @@ jobs:
           ./run-tests.sh --check-flake8
 
   lint-pydocstyle:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -98,7 +98,7 @@ jobs:
           ./run-tests.sh --check-pydocstyle
 
   lint-check-manifest:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -115,7 +115,7 @@ jobs:
           ./run-tests.sh --check-manifest
 
   docs-sphinx:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -139,7 +139,7 @@ jobs:
         run: ./run-tests.sh --check-sphinx
 
   python-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -170,7 +170,7 @@ jobs:
           files: coverage.xml
 
   lint-dockerfile:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -179,7 +179,7 @@ jobs:
         run: ./run-tests.sh --check-dockerfile
 
   docker-build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -188,7 +188,7 @@ jobs:
         run: ./run-tests.sh --check-docker-build
 
   release-docker:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: >
       vars.RELEASE_DOCKER == 'true' &&
       github.event_name == 'push' &&

--- a/requirements.in
+++ b/requirements.in
@@ -1,10 +1,10 @@
 # This file is part of REANA.
-# Copyright (C) 2020, 2022, 2023 CERN.
+# Copyright (C) 2020, 2022, 2023, 2025 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 jq==0.1.7; platform_machine == "x86_64"
-jq==1.4.1; platform_machine == "aarch4"
-jq==1.4.1; platform_machine == "arm64"
+jq==1.2.2; platform_machine == "aarch4"
+jq==1.2.2; platform_machine == "arm64"
 pygraphviz==1.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,8 @@ glob2==0.7                # via packtivity, yadage
 graphviz==0.20.1          # via reana-workflow-engine-yadage (setup.py)
 idna==3.6                 # via jsonschema, requests
 jq==0.1.7 ; platform_machine == "x86_64"  # via -r requirements.in, packtivity, yadage
+jq==1.2.2 ; platform_machine == "aarch64"  # via -r requirements.in, packtivity, yadage
+jq==1.2.2 ; platform_machine == "iarm64"  # via -r requirements.in, packtivity, yadage
 jsonpath-rw==1.4.0        # via packtivity, yadage
 jsonpointer==2.4          # via jsonschema, packtivity, yadage
 jsonref==1.1.0            # via bravado-core, packtivity, yadage, yadage-schemas

--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,8 @@ extras_require = {
     # Using older jq on amd64 due to https://github.com/reanahub/reana-demo-bsm-search/issues/21
     "jq": [
         "jq==0.1.7; platform_machine == 'x86_64'",
-        "jq==1.4.1; platform_machine == 'aarch4'",
-        "jq==1.4.1; platform_machine == 'arm64'",
+        "jq==1.2.2; platform_machine == 'aarch4'",
+        "jq==1.2.2; platform_machine == 'arm64'",
     ],
     "pygraphviz": [
         "pygraphviz>=1.5",


### PR DESCRIPTION
Adds forgotten pin to `requirements.txt` on the `jq` version for aarch64/arm64 architectures.

Downgrades `jq` version to 1.2.2 to be closer to the one used for amd64 architectures.

This solves the problem of running Yadage workflows on aarch64/arm64 platforms.

Closes #281