### PR TITLE
fix(config): use glob for egg-info in flake8 exclude

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,7 +7,7 @@ exclude =
     dist
     docs
     coverage.xml
-    reana_job_controller.egg-info
+    *.egg-info
     .*/
     env/
     .git


### PR DESCRIPTION
The exclude entry pointed to `reana_job_controller.egg-info` due to copy-paste from another repo. Replace it with the `*.egg-info` glob so the entry stays correct regardless of the package name.

Closes reanahub/reana#882