### PR TITLE
ci(linting): add remaining linting and formatting checks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace=true
+
+[*.{css,html,js,json,scss,yaml,yml}]
+indent_size = 2
+
+[*.{py,sh}]
+indent_size = 4
+
+[*.go]
+indent_style = tab

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,17 @@ jobs:
           pip install check-manifest
           ./run-tests.sh --check-manifest
 
+  format-shfmt:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check shell script code formatting
+        run: |
+          sudo apt-get install shfmt
+          ./run-tests.sh --check-shfmt
+
   docs-sphinx:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,20 @@ jobs:
           pip install check-manifest
           ./run-tests.sh --check-manifest
 
+  lint-jsonlint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Lint JSON files
+        run: |
+          npm install jsonlint --global
+          ./run-tests.sh --check-jsonlint
+
   format-shfmt:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,20 @@ jobs:
           sudo apt-get install shfmt
           ./run-tests.sh --check-shfmt
 
+  format-prettier:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Check Prettier code fomatting
+        run: |
+          npm install prettier --global
+          ./run-tests.sh --check-prettier
+
   lint-yamllint:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,20 @@ jobs:
           npm install jsonlint --global
           ./run-tests.sh --check-jsonlint
 
+  lint-markdownlint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Lint Markdown files
+        run: |
+          npm install markdownlint-cli2 --global
+          ./run-tests.sh --check-markdownlint
+
   format-shfmt:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,24 @@ jobs:
           sudo apt-get install shfmt
           ./run-tests.sh --check-shfmt
 
+  lint-yamllint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Lint YAML files
+        run: |
+          pip install yamllint
+          ./run-tests.sh --check-yamllint
+
   docs-sphinx:
     runs-on: ubuntu-24.04
     steps:
@@ -215,8 +233,7 @@ jobs:
   release-docker:
     runs-on: ubuntu-24.04
     if: >
-      vars.RELEASE_DOCKER == 'true' &&
-      github.event_name == 'push' &&
+      vars.RELEASE_DOCKER == 'true' && github.event_name == 'push' &&
       startsWith(github.ref, 'refs/tags/')
     needs:
       - docs-sphinx

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,5 @@
+# Allow prompt dollar sign in console examples without showing output
+MD014: false
+
+# Allow multiple headings with same content (for different releases)
+MD024: false

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+.pytest_cache
+CHANGELOG.md
+docs/openapi.json

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,2 @@
+printWidth: 80
+proseWrap: always

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -5,9 +5,13 @@
     ".": {
       "changelog-sections": [
         { "type": "build", "section": "Build", "hidden": false },
-        { "type": "feat", "section": "Features", "hidden": false  },
+        { "type": "feat", "section": "Features", "hidden": false },
         { "type": "fix", "section": "Bug fixes", "hidden": false },
-        { "type": "perf", "section": "Performance improvements", "hidden": false },
+        {
+          "type": "perf",
+          "section": "Performance improvements",
+          "hidden": false
+        },
         { "type": "refactor", "section": "Code refactoring", "hidden": false },
         { "type": "style", "section": "Code style", "hidden": false },
         { "type": "test", "section": "Test suite", "hidden": false },

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,8 @@
+extends: default
+
+rules:
+  comments:
+    min-spaces-from-content: 1
+  document-start: disable
+  line-length: disable
+  truthy: disable

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -5,6 +5,7 @@ The list of contributors in alphabetical order:
 - [Adelina Lintuluoto](https://orcid.org/0000-0002-0726-1452)
 - [Agisilaos Kounelis](https://orcid.org/0000-0001-9312-3189)
 - [Audrius Mecionis](https://orcid.org/0000-0002-3759-1663)
+- [Cameron McClymont](https://orcid.org/0009-0002-0176-5251)
 - [Camila Diaz](https://orcid.org/0000-0001-5543-797X)
 - [Daniel Prelipcean](https://orcid.org/0000-0002-4855-194X)
 - [Diego Rodriguez](https://orcid.org/0000-0003-0649-2002)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,19 @@
+<!-- markdownlint-disable MD013 -->
+
 # Changelog
 
 ## [0.9.5](https://github.com/reanahub/reana-workflow-engine-yadage/compare/0.9.4...0.9.5) (2024-11-29)
-
 
 ### Build
 
 * **docker:** pin setuptools 70 ([#274](https://github.com/reanahub/reana-workflow-engine-yadage/issues/274)) ([bc505d8](https://github.com/reanahub/reana-workflow-engine-yadage/commit/bc505d84a4092610e883e766ad08d2efefe8d908))
 * **python:** bump shared REANA packages as of 2024-11-28 ([#276](https://github.com/reanahub/reana-workflow-engine-yadage/issues/276)) ([5911143](https://github.com/reanahub/reana-workflow-engine-yadage/commit/59111432c2c5a7fea98a71ffb2d78a9e7c1a47af))
 
-
 ### Features
 
 * **externalbackend:** allow Compute4PUNCH backend options ([#269](https://github.com/reanahub/reana-workflow-engine-yadage/issues/269)) ([1ce8e6a](https://github.com/reanahub/reana-workflow-engine-yadage/commit/1ce8e6a41f14996c50c53fcd7e84565626756ace))
 
 ## [0.9.4](https://github.com/reanahub/reana-workflow-engine-yadage/compare/0.9.3...0.9.4) (2024-03-04)
-
 
 ### Build
 
@@ -23,16 +22,13 @@
 * **python:** bump all required packages as of 2024-03-04 ([#261](https://github.com/reanahub/reana-workflow-engine-yadage/issues/261)) ([2a02e19](https://github.com/reanahub/reana-workflow-engine-yadage/commit/2a02e19bbf1a3c8b29f8185e4946d382aa8f27e5))
 * **python:** bump shared REANA packages as of 2024-03-04 ([#261](https://github.com/reanahub/reana-workflow-engine-yadage/issues/261)) ([493aee1](https://github.com/reanahub/reana-workflow-engine-yadage/commit/493aee14c1224d5d961c792cc12d21bff314b007))
 
-
 ### Bug fixes
 
 * **progress:** correctly handle running and stopped jobs ([#258](https://github.com/reanahub/reana-workflow-engine-yadage/issues/258)) ([56ef6a4](https://github.com/reanahub/reana-workflow-engine-yadage/commit/56ef6a4e434d82d8cfb9916bcfa84a0219bc2e03))
 
-
 ### Code refactoring
 
 * **docs:** move from reST to Markdown ([#259](https://github.com/reanahub/reana-workflow-engine-yadage/issues/259)) ([37f05e6](https://github.com/reanahub/reana-workflow-engine-yadage/commit/37f05e6f864c33b721f7926f60d6f68f9d2f841a))
-
 
 ### Continuous integration
 
@@ -43,128 +39,127 @@
 * **release-please:** update version in Dockerfile ([#254](https://github.com/reanahub/reana-workflow-engine-yadage/issues/254)) ([8f18751](https://github.com/reanahub/reana-workflow-engine-yadage/commit/8f18751696f0ebbf5c0d08b08d9c3e58ee3e3897))
 * **shellcheck:** fix exit code propagation ([#257](https://github.com/reanahub/reana-workflow-engine-yadage/issues/257)) ([8831d9e](https://github.com/reanahub/reana-workflow-engine-yadage/commit/8831d9e319545889b6e4ce1a589e140bb2fa2275))
 
-
 ### Documentation
 
 * **authors:** complete list of contributors ([#260](https://github.com/reanahub/reana-workflow-engine-yadage/issues/260)) ([68f97a0](https://github.com/reanahub/reana-workflow-engine-yadage/commit/68f97a0aff07b16e2707423185925c8d6d22c33b))
 
 ## 0.9.3 (2023-12-14)
 
-- Changes `jq` dependency version on amd64 architecture to older version, making certain Yadage workflows much faster.
+* Changes `jq` dependency version on amd64 architecture to older version, making certain Yadage workflows much faster.
 
 ## 0.9.2 (2023-12-12)
 
-- Adds automated multi-platform container image building for amd64 and arm64 architectures.
-- Adds metadata labels to Dockerfile.
-- Fixes container image building on the arm64 architecture.
+* Adds automated multi-platform container image building for amd64 and arm64 architectures.
+* Adds metadata labels to Dockerfile.
+* Fixes container image building on the arm64 architecture.
 
 ## 0.9.1 (2023-09-27)
 
-- Fixes container image names to be Podman-compatible.
+* Fixes container image names to be Podman-compatible.
 
 ## 0.9.0 (2023-01-19)
 
-- Adds support for specifying `slurm_partition` and `slurm_time` for Slurm compute backend jobs.
-- Adds support for Kerberos authentication for workflow orchestration.
-- Adds support for Rucio authentication for workflow jobs.
-- Changes the base image of the component to Ubuntu 20.04 LTS and reduces final Docker image size by removing build-time dependencies.
+* Adds support for specifying `slurm_partition` and `slurm_time` for Slurm compute backend jobs.
+* Adds support for Kerberos authentication for workflow orchestration.
+* Adds support for Rucio authentication for workflow jobs.
+* Changes the base image of the component to Ubuntu 20.04 LTS and reduces final Docker image size by removing build-time dependencies.
 
 ## 0.8.2 (2022-02-08)
 
-- Changes dependencies to solve compatibility issues with `Yadage 0.20.2` version.
+* Changes dependencies to solve compatibility issues with `Yadage 0.20.2` version.
 
 ## 0.8.1 (2022-02-07)
 
-- Adds support for specifying `kubernetes_job_timeout` for Kubernetes compute backend jobs.
-- Fixes workflow stuck in pending status due to early Yadage fail.
+* Adds support for specifying `kubernetes_job_timeout` for Kubernetes compute backend jobs.
+* Fixes workflow stuck in pending status due to early Yadage fail.
 
 ## 0.8.0 (2021-11-22)
 
-- Adds users quota accounting.
-- Changes workflow specification loading to be done in `reana-commons`.
-- Changes workflow engine to reduce the number of API calls to REANA-Job-Controller.
-- Changes workflow engine to remove duplicated messages to the job status message queue.
+* Adds users quota accounting.
+* Changes workflow specification loading to be done in `reana-commons`.
+* Changes workflow engine to reduce the number of API calls to REANA-Job-Controller.
+* Changes workflow engine to remove duplicated messages to the job status message queue.
 
 ## 0.7.5 (2021-07-05)
 
-- Changes internal dependencies to remove click.
+* Changes internal dependencies to remove click.
 
 ## 0.7.4 (2021-04-28)
 
-- Adds support for specifying `kubernetes_memory_limit` for Kubernetes compute backend jobs.
+* Adds support for specifying `kubernetes_memory_limit` for Kubernetes compute backend jobs.
 
 ## 0.7.3 (2021-03-17)
 
-- Changes workflow engine instantiation to use central REANA-Commons factory.
-- Changes job command strings by removing interpreter when possible and using central REANA-Commons job command serialisation.
+* Changes workflow engine instantiation to use central REANA-Commons factory.
+* Changes job command strings by removing interpreter when possible and using central REANA-Commons job command serialisation.
 
 ## 0.7.2 (2021-02-03)
 
-- Fixes minor code warnings.
-- Changes CI system to include Python flake8 and Dockerfile hadolint checkers.
+* Fixes minor code warnings.
+* Changes CI system to include Python flake8 and Dockerfile hadolint checkers.
 
 ## 0.7.1 (2020-11-10)
 
-- Adds support for specifying `htcondor_max_runtime` and `htcondor_accounting_group` for HTCondor compute backend jobs.
-- Fixes restarting of Yadage workflows.
+* Adds support for specifying `htcondor_max_runtime` and `htcondor_accounting_group` for HTCondor compute backend jobs.
+* Fixes restarting of Yadage workflows.
 
 ## 0.7.0 (2020-10-20)
 
-- Adds creation of workflow visualisation graph by default when a workflow runs.
-- Adds option to specify unpacked Docker images as workflow step requirement.
-- Adds handling of workflow specification load logic that was done before in `reana-client`.
-- Adds support for VOMS proxy as a new authentication method.
-- Adds support for `initfiles` operational option.
-- Adds pinning of all Python dependencies allowing to easily rebuild component images at later times.
-- Changes Yadage workflow engine to version 0.20.1.
-- Changes base image to use Python 3.8.
-- Changes code formatting to respect `black` coding style.
-- Changes documentation to single-page layout.
+* Adds creation of workflow visualisation graph by default when a workflow runs.
+* Adds option to specify unpacked Docker images as workflow step requirement.
+* Adds handling of workflow specification load logic that was done before in `reana-client`.
+* Adds support for VOMS proxy as a new authentication method.
+* Adds support for `initfiles` operational option.
+* Adds pinning of all Python dependencies allowing to easily rebuild component images at later times.
+* Changes Yadage workflow engine to version 0.20.1.
+* Changes base image to use Python 3.8.
+* Changes code formatting to respect `black` coding style.
+* Changes documentation to single-page layout.
 
 ## 0.6.1 (2020-05-25)
 
-- Upgrades REANA-Commons package using latest Kubernetes Python client version.
+* Upgrades REANA-Commons package using latest Kubernetes Python client version.
 
 ## 0.6.0 (2019-12-20)
 
-- Allows to specify compute backend (HTCondor, Kubernetes or Slurm) and
+* Allows to specify compute backend (HTCondor, Kubernetes or Slurm) and
   Kerberos authentication requirement for Yadage workflow jobs.
-- Upgrades Python to 3.6.
-- Upgrades Yadage to 0.20.0.
-- Upgrades Packtivity to 0.14.21.
-- Sets default umask 002 for jobs writing to the workflow workspace.
-- Allows setting UID for the job container runtime user.
-- Moves workflow engine to the same Kubernetes pod with the REANA-Job-Controller
+* Upgrades Python to 3.6.
+* Upgrades Yadage to 0.20.0.
+* Upgrades Packtivity to 0.14.21.
+* Sets default umask 002 for jobs writing to the workflow workspace.
+* Allows setting UID for the job container runtime user.
+* Moves workflow engine to the same Kubernetes pod with the REANA-Job-Controller
   (sidecar pattern).
 
 ## 0.5.0 (2019-04-23)
 
-- Makes workflow engine independent of Celery so that independent workflow
+* Makes workflow engine independent of Celery so that independent workflow
   instances are created on demand for each user.
-- Centralises the initialisation of `WorkflowStatusPublisher`.
-- Introduces CVMFS mounts in job specifications.
-- Makes docker image slimmer by using `python:2.7-slim`.
-- Centralises log level and log format configuration.
+* Centralises the initialisation of `WorkflowStatusPublisher`.
+* Introduces CVMFS mounts in job specifications.
+* Makes docker image slimmer by using `python:2.7-slim`.
+* Centralises log level and log format configuration.
 
 ## 0.4.0 (2018-11-06)
 
-- Improves AMQP re-connection handling. Switches from `pika` to `kombu`.
-- Utilises common openapi client for communication with REANA-Job-Controller.
-- Changes license to MIT.
+* Improves AMQP re-connection handling. Switches from `pika` to `kombu`.
+* Utilises common openapi client for communication with REANA-Job-Controller.
+* Changes license to MIT.
 
 ## 0.3.1 (2018-09-07)
 
-- Pins REANA-Commons and Celery dependencies.
+* Pins REANA-Commons and Celery dependencies.
 
 ## 0.3.0 (2018-08-10)
 
-- Tracks workflow progress.
+* Tracks workflow progress.
 
 ## 0.2.0 (2018-04-19)
 
-- Upgrades Yadage workflow ecosystem versions (Yadage 0.13, Packtivity 0.10).
-- Adds logs to the workflow models in the database.
+* Upgrades Yadage workflow ecosystem versions (Yadage 0.13, Packtivity 0.10).
+* Adds logs to the workflow models in the database.
 
 ## 0.1.0 (2018-01-30)
 
-- Initial public release.
+* Initial public release.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,12 @@
 # Contributing
 
-Bug reports, issues, feature requests, and other contributions are welcome. If you find
-a demonstrable problem that is caused by the REANA code, please:
+Bug reports, issues, feature requests, and other contributions are welcome. If
+you find a demonstrable problem that is caused by the REANA code, please:
 
-1. Search for [already reported problems](https://github.com/reanahub/reana-workflow-engine-yadage/issues).
-2. Check if the issue has been fixed or is still reproducible on the
-   latest `master` branch.
+1. Search for
+   [already reported problems](https://github.com/reanahub/reana-workflow-engine-yadage/issues).
+2. Check if the issue has been fixed or is still reproducible on the latest
+   `master` branch.
 3. Create an issue, ideally with **a test case**.
 
 If you create a pull request fixing a bug or implementing a feature, you can run

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -17,6 +17,8 @@ include LICENSE
 include pytest.ini
 exclude .readthedocs.yaml
 exclude .editorconfig
+exclude .prettierrc.yaml
+exclude .prettierignore
 recursive-include docs *.py
 recursive-include docs *.png
 recursive-include docs *.md

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -16,6 +16,7 @@ include Dockerfile
 include LICENSE
 include pytest.ini
 exclude .readthedocs.yaml
+exclude .editorconfig
 recursive-include docs *.py
 recursive-include docs *.png
 recursive-include docs *.md

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
 
 ## About
 
-REANA-Workflow-Engine-Yadage is a component of the [REANA](http://www.reana.io/) reusable
-and reproducible research data analysis platform. It takes care of instantiating,
-executing and managing [Yadage](https://github.com/diana-hep/yadage) based computational
-workflows.
+REANA-Workflow-Engine-Yadage is a component of the [REANA](http://www.reana.io/)
+reusable and reproducible research data analysis platform. It takes care of
+instantiating, executing and managing
+[Yadage](https://github.com/diana-hep/yadage) based computational workflows.
 
 ## Features
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,6 @@
+<!-- markdownlint-disable MD041 -->
+<!-- markdownlint-disable MD033 -->
+
 ```{include} ../README.md
 :end-before: "## About"
 ```

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -91,6 +91,10 @@ check_shfmt() {
     shfmt -d .
 }
 
+check_markdownlint() {
+    markdownlint-cli2 "**/*.md"
+}
+
 check_all() {
     check_commitlint
     check_shellcheck
@@ -105,6 +109,7 @@ check_all() {
     check_jsonlint
     check_yamllint
     check_shfmt
+    check_markdownlint
 }
 
 if [ $# -eq 0 ]; then
@@ -127,6 +132,7 @@ case $arg in
 --check-jsonlint) check_jsonlint ;;
 --check-yamllint) check_yamllint ;;
 --check-shfmt) check_shfmt ;;
+--check-markdownlint) check_markdownlint ;;
 --check-all) check_all ;;
 *) echo "[ERROR] Invalid argument '$arg'. Exiting." && exit 1 ;;
 esac

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -83,6 +83,10 @@ check_jsonlint() {
     find . -name "*.json" -exec jsonlint -q {} \+
 }
 
+check_yamllint() {
+    yamllint .
+}
+
 check_shfmt() {
     shfmt -d .
 }
@@ -99,6 +103,7 @@ check_all() {
     check_dockerfile
     check_docker_build
     check_jsonlint
+    check_yamllint
     check_shfmt
 }
 
@@ -120,6 +125,7 @@ case $arg in
 --check-dockerfile) check_dockerfile ;;
 --check-docker-build) check_docker_build ;;
 --check-jsonlint) check_jsonlint ;;
+--check-yamllint) check_yamllint ;;
 --check-shfmt) check_shfmt ;;
 --check-all) check_all ;;
 *) echo "[ERROR] Invalid argument '$arg'. Exiting." && exit 1 ;;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -95,6 +95,10 @@ check_markdownlint() {
     markdownlint-cli2 "**/*.md"
 }
 
+check_prettier() {
+    prettier -c .
+}
+
 check_all() {
     check_commitlint
     check_shellcheck
@@ -110,6 +114,7 @@ check_all() {
     check_yamllint
     check_shfmt
     check_markdownlint
+    check_prettier
 }
 
 if [ $# -eq 0 ]; then
@@ -133,6 +138,7 @@ case $arg in
 --check-yamllint) check_yamllint ;;
 --check-shfmt) check_shfmt ;;
 --check-markdownlint) check_markdownlint ;;
+--check-prettier) check_prettier ;;
 --check-all) check_all ;;
 *) echo "[ERROR] Invalid argument '$arg'. Exiting." && exit 1 ;;
 esac

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -79,6 +79,10 @@ check_docker_build() {
     docker build -t docker.io/reanahub/reana-workflow-engine-yadage .
 }
 
+check_jsonlint() {
+    find . -name "*.json" -exec jsonlint -q {} \+
+}
+
 check_shfmt() {
     shfmt -d .
 }
@@ -94,6 +98,7 @@ check_all() {
     check_pytest
     check_dockerfile
     check_docker_build
+    check_jsonlint
     check_shfmt
 }
 
@@ -114,6 +119,7 @@ case $arg in
 --check-pytest) check_pytest ;;
 --check-dockerfile) check_dockerfile ;;
 --check-docker-build) check_docker_build ;;
+--check-jsonlint) check_jsonlint ;;
 --check-shfmt) check_shfmt ;;
 --check-all) check_all ;;
 *) echo "[ERROR] Invalid argument '$arg'. Exiting." && exit 1 ;;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -9,7 +9,7 @@
 set -o errexit
 set -o nounset
 
-check_commitlint () {
+check_commitlint() {
     from=${2:-master}
     to=${3:-HEAD}
     pr=${4:-[0-9]+}
@@ -31,7 +31,7 @@ check_commitlint () {
         # (iii) check absence of merge commits in feature branches
         if [ "$commit_number_of_parents" -gt 1 ]; then
             if echo "$commit_title" | grep -qE "^chore\(.*\): merge "; then
-                break  # skip checking maint-to-master merge commits
+                break # skip checking maint-to-master merge commits
             else
                 echo "✖   Merge commits are not allowed in feature branches: $commit_title"
                 found=1
@@ -43,43 +43,47 @@ check_commitlint () {
     fi
 }
 
-check_shellcheck () {
+check_shellcheck() {
     find . -name "*.sh" -exec shellcheck {} \+
 }
 
-check_pydocstyle () {
+check_pydocstyle() {
     pydocstyle reana_workflow_engine_yadage
 }
 
-check_black () {
+check_black() {
     black --check .
 }
 
-check_flake8 () {
+check_flake8() {
     flake8 .
 }
 
-check_manifest () {
+check_manifest() {
     check-manifest
 }
 
-check_sphinx () {
+check_sphinx() {
     sphinx-build -qnNW docs docs/_build/html
 }
 
-check_pytest () {
+check_pytest() {
     pytest
 }
 
-check_dockerfile () {
-    docker run -i --rm docker.io/hadolint/hadolint:v2.12.0 < Dockerfile
+check_dockerfile() {
+    docker run -i --rm docker.io/hadolint/hadolint:v2.12.0 <Dockerfile
 }
 
-check_docker_build () {
+check_docker_build() {
     docker build -t docker.io/reanahub/reana-workflow-engine-yadage .
 }
 
-check_all () {
+check_shfmt() {
+    shfmt -d .
+}
+
+check_all() {
     check_commitlint
     check_shellcheck
     check_pydocstyle
@@ -90,6 +94,7 @@ check_all () {
     check_pytest
     check_dockerfile
     check_docker_build
+    check_shfmt
 }
 
 if [ $# -eq 0 ]; then
@@ -99,15 +104,17 @@ fi
 
 arg="$1"
 case $arg in
-    --check-commitlint) check_commitlint "$@";;
-    --check-shellcheck) check_shellcheck;;
-    --check-pydocstyle) check_pydocstyle;;
-    --check-black) check_black;;
-    --check-flake8) check_flake8;;
-    --check-manifest) check_manifest;;
-    --check-sphinx) check_sphinx;;
-    --check-pytest) check_pytest;;
-    --check-dockerfile) check_dockerfile;;
-    --check-docker-build) check_docker_build;;
-    *) echo "[ERROR] Invalid argument '$arg'. Exiting." && exit 1;;
+--check-commitlint) check_commitlint "$@" ;;
+--check-shellcheck) check_shellcheck ;;
+--check-pydocstyle) check_pydocstyle ;;
+--check-black) check_black ;;
+--check-flake8) check_flake8 ;;
+--check-manifest) check_manifest ;;
+--check-sphinx) check_sphinx ;;
+--check-pytest) check_pytest ;;
+--check-dockerfile) check_dockerfile ;;
+--check-docker-build) check_docker_build ;;
+--check-shfmt) check_shfmt ;;
+--check-all) check_all ;;
+*) echo "[ERROR] Invalid argument '$arg'. Exiting." && exit 1 ;;
 esac


### PR DESCRIPTION
Introduce remaining file formatting checks to `run-tests.sh` and to the GitHub CI:
- [x] `.editorconfig` for consistent character formatting across the repo
- [x] `yamllint` for YAML linting
- [x] `jsonlint` for JSON linting
- [x] `shfmt` for shell script formatting
- [x] `markdownlint` for markdown linting
- [x] `prettier` for various other formatting such as `.js` files

Closes #287