### PR TITLE
refactor(pytest): drop pytest-reana and use pytest directly

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -5,4 +5,4 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 
 [pytest]
-addopts = --ignore=docs --cov=reana_workflow_engine_yadage --cov-report=term-missing --cov-report=xml
+addopts = --ignore=docs --ignore=modules --cov=reana_workflow_engine_yadage --cov-report=term-missing --cov-report=xml

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ pyrsistent==0.20.0        # via jsonschema
 python-dateutil==2.9.0.post0  # via arrow, bravado, bravado-core
 pytz==2026.1.post1        # via bravado-core
 pyyaml==6.0.3             # via bravado, bravado-core, packtivity, reana-commons, swagger-spec-validator, yadage, yadage-schemas
-reana-commons[yadage]==0.95.0a14  # via reana-workflow-engine-yadage (setup.py)
+reana-commons[yadage]==0.95.0a16	# via reana-workflow-engine-yadage (setup.py)
 requests[security]==2.33.0  # via bravado, bravado-core, packtivity, reana-workflow-engine-yadage (setup.py), yadage, yadage-schemas
 rfc3339-validator==0.1.4  # via jsonschema
 rfc3987==1.3.8            # via jsonschema, reana-workflow-engine-yadage (setup.py)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,29 +7,26 @@
 adage==0.11.0             # via reana-commons, reana-workflow-engine-yadage (setup.py), yadage
 amqp==5.3.1               # via kombu
 appdirs==1.4.4            # via fs
-arrow==1.4.0              # via isoduration
 attrs==26.1.0             # via jsonschema
 bracex==2.6               # via wcmatch
 bravado==10.3.2           # via reana-commons
 bravado-core==6.1.0       # via bravado, reana-commons
-certifi==2026.2.25        # via requests
-charset-normalizer==3.4.6  # via requests
+certifi==2026.4.22        # via requests
+charset-normalizer==3.4.7  # via requests
 checksumdir==1.1.9        # via packtivity, reana-commons, yadage
-click==8.3.1              # via packtivity, reana-commons, yadage, yadage-schemas
+click==8.3.3              # via packtivity, reana-commons, yadage, yadage-schemas
 decorator==5.2.1          # via jsonpath-rw
-fqdn==1.5.1               # via jsonschema
 fs==2.4.16                # via reana-commons
-gherkin-official==39.0.0  # via reana-commons
+gherkin-official==39.1.0  # via reana-commons
 glob2==0.7                # via packtivity, yadage
 graphviz==0.21            # via reana-workflow-engine-yadage (setup.py)
-idna==3.11                # via jsonschema, requests
-importlib-resources==6.5.2  # via swagger-spec-validator
-isoduration==20.11.0      # via jsonschema
+idna==3.14                # via jsonschema, requests
+importlib-resources==7.1.0  # via swagger-spec-validator
 jq==1.7.0                 # via packtivity, reana-workflow-engine-yadage (setup.py), yadage
 jsonpath-rw==1.4.0        # via packtivity, yadage
 jsonpointer==3.1.1        # via jsonschema, packtivity, yadage
 jsonref==1.1.0            # via bravado-core, packtivity, yadage, yadage-schemas
-jsonschema[format]==4.9.1  # via bravado-core, packtivity, reana-commons, swagger-spec-validator, yadage, yadage-schemas
+jsonschema[format]==3.2.0  # via bravado-core, packtivity, reana-commons, swagger-spec-validator, yadage, yadage-schemas
 kombu==5.6.2              # via reana-commons
 markupsafe==3.0.3         # via werkzeug
 mock==3.0.5               # via packtivity, reana-commons
@@ -37,9 +34,9 @@ monotonic==1.6            # via bravado
 msgpack==1.1.2            # via bravado-core
 msgpack-python==0.5.6     # via bravado
 networkx==3.6.1           # via adage
-packaging==26.0           # via kombu
+packaging==26.2           # via kombu
 packtivity==0.16.2        # via reana-workflow-engine-yadage (setup.py), yadage
-parse==1.21.1             # via reana-commons
+parse==1.22.0             # via reana-commons
 ply==3.11                 # via jsonpath-rw
 psutil==7.2.2             # via yadage
 pydot==4.0.1              # via reana-workflow-engine-yadage (setup.py)
@@ -47,24 +44,23 @@ pydotplus==2.0.2          # via reana-workflow-engine-yadage (setup.py)
 pygraphviz==1.14          # via reana-workflow-engine-yadage (setup.py)
 pyparsing==3.3.2          # via pydot, pydotplus
 pyrsistent==0.20.0        # via jsonschema
-python-dateutil==2.9.0.post0  # via arrow, bravado, bravado-core
-pytz==2026.1.post1        # via bravado-core
+python-dateutil==2.9.0.post0  # via bravado, bravado-core
+pytz==2026.2              # via bravado-core
 pyyaml==6.0.3             # via bravado, bravado-core, packtivity, reana-commons, swagger-spec-validator, yadage, yadage-schemas
-reana-commons[yadage]==0.95.0a16	# via reana-workflow-engine-yadage (setup.py)
-requests[security]==2.33.0  # via bravado, bravado-core, packtivity, reana-workflow-engine-yadage (setup.py), yadage, yadage-schemas
-rfc3339-validator==0.1.4  # via jsonschema
+reana-commons[yadage]==0.95.0a16  # via reana-workflow-engine-yadage (setup.py)
+requests[security]==2.34.0  # via bravado, bravado-core, packtivity, reana-workflow-engine-yadage (setup.py), yadage, yadage-schemas
 rfc3987==1.3.8            # via jsonschema, reana-workflow-engine-yadage (setup.py)
-simplejson==3.20.2        # via bravado, bravado-core
-six==1.17.0               # via bravado, bravado-core, fs, jsonpath-rw, mock, python-dateutil, rfc3339-validator
+simplejson==4.1.1         # via bravado, bravado-core
+six==1.17.0               # via bravado, bravado-core, fs, jsonpath-rw, jsonschema, mock, python-dateutil
+strict-rfc3339==0.7       # via jsonschema
 swagger-spec-validator==3.0.4  # via bravado-core
 typing-extensions==4.15.0  # via bravado, gherkin-official, swagger-spec-validator
-tzdata==2025.3            # via arrow, kombu
-uri-template==1.3.0       # via jsonschema
-urllib3==2.6.3            # via requests
+tzdata==2026.2            # via kombu
+urllib3==2.7.0            # via requests
 vine==5.1.0               # via amqp, kombu
 wcmatch==8.4.1            # via reana-commons
 webcolors==25.10.0        # via jsonschema
-werkzeug==3.1.7           # via reana-commons
+werkzeug==3.1.8           # via reana-commons
 yadage==0.20.1            # via reana-commons, reana-workflow-engine-yadage (setup.py)
 yadage-schemas==0.10.6    # via packtivity, reana-commons, reana-workflow-engine-yadage (setup.py), yadage
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ extras_require = {
         "sphinx-rtd-theme>=0.1.9",
     ],
     "tests": [
-        "pytest-reana>=0.95.0a2,<0.96.0",
+        "pytest>=7.0.0,<9.0.0",
+        "pytest-cov>=3.0.0,<4.0",
     ],
     "jq": [
         "jq==1.7.0",
@@ -56,7 +57,7 @@ install_requires = [
     "packtivity==0.16.2",
     "yadage==0.20.1",
     "yadage-schemas==0.10.6",
-    "reana-commons[yadage]>=0.95.0a14,<0.96.0",
+    "reana-commons[yadage]>=0.95.0a16,<0.96.0",
     "requests>=2.25.1",
     "rfc3987==1.3.8",  # FIXME remove once yadage-schemas solves yadage deps.
 ]


### PR DESCRIPTION
This engine never used any fixture from pytest-reana; the dependency
only pulled pytest and friends transitively. Replace it with direct
pytest usage.

Closes https://github.com/reanahub/pytest-reana/issues/156