### PR TITLE
fix(externalbackend): handle rejection without noisy traceback 

### DIFF
--- a/reana_workflow_engine_yadage/cli.py
+++ b/reana_workflow_engine_yadage/cli.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2019, 2020, 2021 CERN.
+# Copyright (C) 2019, 2020, 2021, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -18,6 +18,7 @@ from reana_commons.config import (
     REANA_LOG_LEVEL,
     REANA_WORKFLOW_UMASK,
 )
+from reana_commons.errors import REANAJobControllerSubmissionError
 from reana_commons.workflow_engine import create_workflow_engine_command
 from yadage.steering_api import steering_ctx
 from yadage.utils import setupbackend_fromstring
@@ -31,6 +32,26 @@ from .tracker import REANATracker
 
 logging.basicConfig(level=REANA_LOG_LEVEL, format=REANA_LOG_FORMAT)
 log = logging.getLogger(LOGGING_MODULE)
+
+
+class _SuppressAdageSubmissionTraceback(logging.Filter):
+    """Drop adage's bare-except traceback for known job-submission failures.
+
+    Adage's main polling loop wraps node submission in a bare ``except:``
+    that logs ``log.exception('some weird exception caught in adage process
+    loop')`` before re-raising. For a ``REANAJobControllerSubmissionError``
+    the wrapper in ``reana_commons.workflow_engine`` already publishes a
+    clean failure message, so adage's duplicate traceback is pure noise.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        exc_info = record.exc_info
+        if exc_info and isinstance(exc_info[1], REANAJobControllerSubmissionError):
+            return False
+        return True
+
+
+logging.getLogger("adage").addFilter(_SuppressAdageSubmissionTraceback())
 
 
 def run_yadage_workflow_engine_adapter(

--- a/reana_workflow_engine_yadage/externalbackend.py
+++ b/reana_workflow_engine_yadage/externalbackend.py
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2017-2021, 2022, 2025 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -13,6 +13,7 @@ from typing import Any, Dict, List, Union
 from packtivity.asyncbackends import ExternalAsyncProxy
 from packtivity.syncbackends import build_job, finalize_inputs, packconfig, publish
 from reana_commons.api_client import JobControllerAPIClient as RJC_API_Client
+from reana_commons.errors import REANAJobControllerSubmissionError
 
 from .config import (
     JOB_TERMINAL_STATUSES,
@@ -138,7 +139,14 @@ class ExternalBackend:
             **resources_parameters,
         }
 
-        job_submit_response = self.rjc_api_client.submit(**job_request_body)
+        try:
+            job_submit_response = self.rjc_api_client.submit(**job_request_body)
+        except REANAJobControllerSubmissionError as e:
+            # Suppress the bravado HTTPForbidden context so the workflow-
+            # engine wrapper publishes a clean failure message instead of
+            # dumping the full client traceback. Re-raise the same instance
+            # so the "Job submission error: " prefix is applied only once.
+            raise e from None
         job_id = job_submit_response.get("job_id")
 
         log.info(f"Submitted job with id: {job_id}")

--- a/tests/test_externalbackend.py
+++ b/tests/test_externalbackend.py
@@ -1,14 +1,18 @@
 # This file is part of REANA.
-# Copyright (C) 2021, 2025 CERN.
+# Copyright (C) 2021, 2022, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """REANA-Workflow-Engine-Yadage ExternalBackend tests."""
 
+import logging
 from typing import List, Dict, Any, Union
+from unittest import mock
 
 import pytest
+
+from reana_commons.errors import REANAJobControllerSubmissionError
 
 
 class TestExternalBackend:
@@ -47,3 +51,98 @@ class TestExternalBackend:
         from reana_workflow_engine_yadage.externalbackend import ExternalBackend
 
         assert ExternalBackend._get_resources(input_parameters) == final_parameters
+
+    def test_submit_drops_bravado_chain_on_rejection(self):
+        """Job-controller rejection re-raises without the bravado chain.
+
+        Without ``from None`` the noisy ``HTTPForbidden`` cause would be
+        chained onto the exception adage's bare ``except:`` logs.
+        """
+        from reana_workflow_engine_yadage.externalbackend import ExternalBackend
+
+        backend = ExternalBackend.__new__(ExternalBackend)
+        backend.rjc_api_client = mock.Mock()
+        backend.config = mock.Mock()
+        backend.jobs_statuses = {}
+        backend._fail_info = ""
+
+        # api_client.py raises the exception with the raw message; the
+        # "Job submission error: " prefix is added by __str__. Mirror that
+        # here so the test would catch a double-prefix regression.
+        raw_message = (
+            'The "kubernetes_uid" requested (500) is below the '
+            "cluster-configured minimum (1000)."
+        )
+        original = REANAJobControllerSubmissionError(raw_message)
+        backend.rjc_api_client.submit.side_effect = original
+
+        spec = {
+            "process": {"process_type": "string-interpolated-cmd", "cmd": "echo hi"},
+            "environment": {"image": "busybox", "resources": []},
+            "publisher": {},
+        }
+        parameters = mock.MagicMock()
+        state = mock.MagicMock()
+        metadata = {"name": "step"}
+
+        with mock.patch(
+            "reana_workflow_engine_yadage.externalbackend.finalize_inputs",
+            return_value=(parameters, state),
+        ), mock.patch(
+            "reana_workflow_engine_yadage.externalbackend.build_job",
+            return_value={"command": "echo hi"},
+        ), pytest.raises(
+            REANAJobControllerSubmissionError
+        ) as excinfo:
+            backend.submit(spec, parameters, state, metadata)
+
+        assert excinfo.value is original
+        assert str(excinfo.value) == f"Job submission error: {raw_message}"
+        assert excinfo.value.__cause__ is None
+        assert excinfo.value.__suppress_context__ is True
+
+
+class TestAdageLogSuppression:
+    """The cli module installs a filter that drops adage's duplicate traceback."""
+
+    @staticmethod
+    def _get_filter():
+        # Importing cli installs the filter on the "adage" logger.
+        import reana_workflow_engine_yadage.cli  # noqa: F401
+        from reana_workflow_engine_yadage.cli import (
+            _SuppressAdageSubmissionTraceback,
+        )
+
+        for f in logging.getLogger("adage").filters:
+            if isinstance(f, _SuppressAdageSubmissionTraceback):
+                return f
+        raise AssertionError("filter not installed on adage logger")
+
+    @staticmethod
+    def _make_record(exc):
+        import sys
+
+        try:
+            raise exc
+        except type(exc):
+            return logging.getLogger("adage").makeRecord(
+                name="adage",
+                level=logging.ERROR,
+                fn=__file__,
+                lno=0,
+                msg="some weird exception caught in adage process loop",
+                args=(),
+                exc_info=sys.exc_info(),
+            )
+
+    def test_filter_drops_submission_error_records(self):
+        record = self._make_record(
+            REANAJobControllerSubmissionError(
+                "Job submission error: cluster refused the job."
+            )
+        )
+        assert self._get_filter().filter(record) is False
+
+    def test_filter_keeps_unrelated_errors(self):
+        record = self._make_record(RuntimeError("something else"))
+        assert self._get_filter().filter(record) is True


### PR DESCRIPTION
When job-controller refuses a job (HTTP 403 from a `kubernetes_uid`, `kubernetes_memory_limit` or `kubernetes_cpu_limit` outside cluster limits), `REANAJobControllerSubmissionError` propagates through adage's polling loop. Adage's bare `except:` then dumps the full bravado plus adage traceback before re-raising. The workflow engine wrapper already publishes a clean failure message, so the traceback is noise that obscures the real cause.

Catch the exception at the submission site and re-raise the same instance with `from None` to suppress the bravado context, and add a logging filter on the `adage` logger that drops the "weird exception" record when its cause is this specific exception. Other unexpected exceptions still emit their full traceback.

Yadage now produces the same clean two-line failure output as the CWL, Serial and Snakemake engines.

Closes #300