### PR TITLE
feat(externalbackend): pass scoped user secret names

### DIFF
--- a/reana_workflow_engine_yadage/cli.py
+++ b/reana_workflow_engine_yadage/cli.py
@@ -9,6 +9,7 @@
 
 from __future__ import absolute_import, print_function
 
+import json
 import logging
 import os
 import yaml
@@ -60,6 +61,7 @@ def run_yadage_workflow_engine_adapter(
     workflow_uuid=None,
     workflow_workspace=None,
     workflow_json=None,
+    workflow_resources=None,
     workflow_parameters=None,
     operational_options={},
     **kwargs,
@@ -67,6 +69,7 @@ def run_yadage_workflow_engine_adapter(
     """Run a ``yadage`` workflow."""
     os.environ["workflow_uuid"] = workflow_uuid
     os.environ["workflow_workspace"] = workflow_workspace
+    os.environ["REANA_WORKFLOW_RESOURCES"] = json.dumps(workflow_resources or {})
     os.umask(REANA_WORKFLOW_UMASK)
 
     tracker = REANATracker(identifier=workflow_uuid, publisher=publisher)

--- a/reana_workflow_engine_yadage/externalbackend.py
+++ b/reana_workflow_engine_yadage/externalbackend.py
@@ -6,6 +6,7 @@
 """REANA-Workflow-Engine-yadage REANA packtivity backend."""
 
 import base64
+import json
 import logging
 import os
 from typing import Any, Dict, List, Union
@@ -14,6 +15,18 @@ from packtivity.asyncbackends import ExternalAsyncProxy
 from packtivity.syncbackends import build_job, finalize_inputs, packconfig, publish
 from reana_commons.api_client import JobControllerAPIClient as RJC_API_Client
 from reana_commons.errors import REANAJobControllerSubmissionError
+
+try:
+    from reana_commons.k8s.secrets import resolve_secret_names
+except (ImportError, ModuleNotFoundError):
+
+    def resolve_secret_names(scoped_secret_names, workflow_resources=None):
+        """Resolve a step-local allowlist against the workflow-global default."""
+        if scoped_secret_names is not None:
+            return scoped_secret_names
+        workflow_resources = workflow_resources or {}
+        return workflow_resources.get("secret_names")
+
 
 from .config import (
     JOB_TERMINAL_STATUSES,
@@ -58,12 +71,18 @@ class ExternalBackend:
         """Initialize the REANA packtivity backend."""
         self.config = packconfig()
         self.rjc_api_client = RJC_API_Client("reana-job-controller")
+        self.workflow_resources = json.loads(
+            os.getenv("REANA_WORKFLOW_RESOURCES", "{}")
+        )
 
         self.jobs_statuses = {}
         self._fail_info = ""
 
     @staticmethod
-    def _get_resources(resources: List[Union[Dict, Any]]) -> Dict[str, Any]:
+    def _get_resources(
+        resources: List[Union[Dict, Any]],
+        workflow_resources: Dict[str, Any] = None,
+    ) -> Dict[str, Any]:
         parameters = {}
 
         def set_parameter(resource: Dict[str, Any], key: str) -> None:
@@ -88,6 +107,7 @@ class ExternalBackend:
             set_parameter(item, "unpacked_img")
             set_parameter(item, "voms_proxy")
             set_parameter(item, "rucio")
+            set_parameter(item, "secret_names")
             set_parameter(item, "htcondor_max_runtime")
             set_parameter(item, "htcondor_accounting_group")
             set_parameter(item, "htcondor_request_cpus")
@@ -102,6 +122,11 @@ class ExternalBackend:
 
         if "kerberos" not in parameters:
             parameters["kerberos"] = WORKFLOW_KERBEROS
+        parameters["secret_names"] = resolve_secret_names(
+            parameters.get("secret_names"), workflow_resources
+        )
+        if parameters["secret_names"] is None:
+            parameters.pop("secret_names")
 
         return parameters
 
@@ -127,7 +152,9 @@ class ExternalBackend:
             image = f"{image}:{imagetag}"
 
         resources = spec["environment"].get("resources", [])
-        resources_parameters = self._get_resources(resources)
+        resources_parameters = self._get_resources(
+            resources, getattr(self, "workflow_resources", {})
+        )
 
         log.debug(f"would run job {job}")
 

--- a/tests/test_externalbackend.py
+++ b/tests/test_externalbackend.py
@@ -17,7 +17,7 @@ from reana_commons.errors import REANAJobControllerSubmissionError
 
 class TestExternalBackend:
     @pytest.mark.parametrize(
-        "input_parameters,final_parameters",
+        "input_parameters,workflow_resources,final_parameters",
         [
             (
                 [
@@ -29,6 +29,7 @@ class TestExternalBackend:
                     {"kubernetes_memory_request": None},
                     {"kubernetes_memory_limit": None},
                 ],
+                {},
                 {
                     "compute_backend": "kubernetes",
                     "kubernetes_job_timeout": 20,
@@ -37,20 +38,48 @@ class TestExternalBackend:
             ),
             (
                 [{"kubernetes_job_timeout": 10}, {"kubernetes_job_timeout": 30}],
+                {},
                 {"kubernetes_job_timeout": 30, "kerberos": False},
             ),
             (
                 [{"kerberos": True}],
+                {},
                 {"kerberos": True},
+            ),
+            (
+                [{"secret_names": []}],
+                {},
+                {"kerberos": False, "secret_names": []},
+            ),
+            (
+                [{"secret_names": ["alpha", "beta"]}],
+                {},
+                {"kerberos": False, "secret_names": ["alpha", "beta"]},
+            ),
+            (
+                [],
+                {"kerberos": False, "secret_names": ["global"]},
+                {"kerberos": False, "secret_names": ["global"]},
+            ),
+            (
+                [{"secret_names": []}],
+                {"secret_names": ["global"]},
+                {"kerberos": False, "secret_names": []},
             ),
         ],
     )
     def test_get_resources(
-        self, input_parameters: List[Union[Dict, Any]], final_parameters: Dict[str, Any]
+        self,
+        input_parameters: List[Union[Dict, Any]],
+        workflow_resources: Dict[str, Any],
+        final_parameters: Dict[str, Any],
     ):
         from reana_workflow_engine_yadage.externalbackend import ExternalBackend
 
-        assert ExternalBackend._get_resources(input_parameters) == final_parameters
+        assert (
+            ExternalBackend._get_resources(input_parameters, workflow_resources)
+            == final_parameters
+        )
 
     def test_submit_drops_bravado_chain_on_rejection(self):
         """Job-controller rejection re-raises without the bravado chain.


### PR DESCRIPTION
Forward optional secret allowlists through Yadage backend job submission so workflow defaults, stage overrides, and explicit empty allowlists reach the job controller intact.

Closes reanahub/reana#978