### PR TITLE
Add features for GPU, notification option and email address

### DIFF
--- a/reana_workflow_engine_yadage/externalbackend.py
+++ b/reana_workflow_engine_yadage/externalbackend.py
@@ -92,7 +92,10 @@ class ExternalBackend:
             set_parameter(item, "slurm_partition")
             set_parameter(item, "slurm_time")
             set_parameter(item, "c4p_cpu_cores")
+            set_parameter(item, "c4p_request_gpus")
             set_parameter(item, "c4p_memory_limit")
+            set_parameter(item, "c4p_notification")
+            set_parameter(item, "c4p_email_address")
             set_parameter(item, "c4p_additional_requirements")
 
         if "kerberos" not in parameters:


### PR DESCRIPTION
Dear Tibor, dear all,

The following optional parameters have been added for the Compute4PUNCH backend:

C4P_REQUEST_GPUS: Number of GPUs used to run the REANA jobs.
C4P_NOTIFICATION: Notification option used by the REANA jobs.
C4P_EMAIL_ADDRESS: User email address used by the REANA jobs.

Their purposes are the following:

C4P_REQUEST_GPUS: access to the GPUs of the Compute4PUNCH infrastructure.
C4P_NOTIFICATION: notification option in HTCondor (Always | Complete | Start | Error | Never).
C4P_EMAIL_ADDRESS: user email, to be notified about the job status and about the remaining life time of the Mytoken used to periodically renew the access token (required to access the Storage4PUNCH infrastructure).

Thanks a lot in advance for your feedback!

Best wishes,
Benoit Roland